### PR TITLE
Add a generic mechanism for adding kubelet extra args

### DIFF
--- a/ansible/roles/kubernetes-common/defaults/main.yml
+++ b/ansible/roles/kubernetes-common/defaults/main.yml
@@ -3,4 +3,5 @@ kubernetes_common:
   api_fqdn: k8s.example.com
   api_ip: 10.10.10.3
   primary_interface: enp0s8
+  # kubelet_extra_args is a dict of arg:value (ie. 'node-ip: 1.1.1.1' for '--node-ip=1.1.1.1')
   kubelet_extra_args: {}

--- a/ansible/roles/kubernetes-common/defaults/main.yml
+++ b/ansible/roles/kubernetes-common/defaults/main.yml
@@ -3,3 +3,4 @@ kubernetes_common:
   api_fqdn: k8s.example.com
   api_ip: 10.10.10.3
   primary_interface: enp0s8
+  kubelet_extra_args: {}

--- a/ansible/roles/kubernetes-common/tasks/main.yml
+++ b/ansible/roles/kubernetes-common/tasks/main.yml
@@ -3,11 +3,17 @@
     kubernetes_node_ip: "{{ hostvars[inventory_hostname]['ansible_'~item]['ipv4']['address'] }}"
   with_items:
     - enp0s8
+  when: vagrant_host|bool == True
 
-- name: drop vagrant node ip flag for the kubelet
+- name: create kubelet config directory
+  file:
+    dest: /etc/systemd/system/kubelet.service.d
+    state: directory
+
+- name: drop extra args kubelet config
   template:
-    dest: /etc/systemd/system/kubelet.service.d/09-vagrant.conf
-    src: etc/systemd/system/kubelet.service.d/09-vagrant.conf
-  when: vagrant_host == True
+    dest: /etc/systemd/system/kubelet.service.d/09-extra-args.conf
+    src: etc/systemd/system/kubelet.service.d/09-extra-args.conf
   notify:
     - restart kubelet
+  when: vagrant_host|bool == True or kubernetes_common.kubelet_extra_args

--- a/ansible/roles/kubernetes-common/tasks/main.yml
+++ b/ansible/roles/kubernetes-common/tasks/main.yml
@@ -2,8 +2,8 @@
 - set_fact:
     kubernetes_node_ip: "{{ hostvars[inventory_hostname]['ansible_'~item]['ipv4']['address'] }}"
   with_items:
-    - enp0s8
-  when: vagrant_host|bool == True
+    - "{{ kubernetes_common.primary_interface }}"
+  when: kubernetes_common.primary_interface is defined
 
 - name: create kubelet config directory
   file:
@@ -16,4 +16,4 @@
     src: etc/systemd/system/kubelet.service.d/09-extra-args.conf
   notify:
     - restart kubelet
-  when: vagrant_host|bool == True or kubernetes_common.kubelet_extra_args
+  when: kubernetes_common.primary_interface is defined or kubernetes_common.kubelet_extra_args is defined

--- a/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-extra-args.conf
+++ b/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-extra-args.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_EXTRA_ARGS={% if vagrant_host|bool %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common.kubelet_extra_args.items() %} --{{k}}={{v}}{%- endfor %}"
+Environment="KUBELET_EXTRA_ARGS={% if kubernetes_common.primary_interface is defined %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common.get('kubelet_extra_args', {}).items() %} --{{k}}='{{v}}'{%- endfor %}"

--- a/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-extra-args.conf
+++ b/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-extra-args.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="KUBELET_EXTRA_ARGS={% if vagrant_host|bool %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common.kubelet_extra_args.items() %} --{{k}}={{v}}{%- endfor %}"

--- a/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-vagrant.conf
+++ b/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-vagrant.conf
@@ -1,2 +1,0 @@
-[Service]
-Environment="KUBELET_EXTRA_ARGS= --node-ip={{ kubernetes_node_ip }}"


### PR DESCRIPTION
The kubelet packages structure the systemd configs such that they may be
included lexically. As we would like to manipulate the flags passed to
the kubelet, provide a mechanism for that to happemn.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>