### PR TITLE
Update docs for repo and for packer builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,31 @@
 wardroom
 ========
-A tool for creating Kubernetes-ready base operating system images. wardroom leverages Packer to build golden images of Kubernetes deploymens across a wide variety of operating systems as well as image formats.
+A tool for creating Kubernetes-ready base operating system images. wardroom leverages [Packer](https://github.com/hashicorp/packer) to build golden images of Kubernetes deploymens across a wide variety of operating systems as well as image formats. This repo is the basis for the images used in Heptio's [aws-quickstart](https://github.com/heptio/ws-quickstart).
 
 supported operating systems
 ---------------------------
 - Ubuntu 16.04 (Xenial)
 - CentOS 7
 
+currently supported image formats (more to follow)
+--------------------------------------------------
+- AMI
+
 image building
 --------------
-All images are built with Packer.
+All images are built with Packer, and configuration and details may be found in the [packer](./packer) directory.
+
+contributing
+------------
+See our [contributing](CONTRIBUTING.md) guidelines and our [code of conduct](CODE-OF-CONDUCT.md). Contributions welcome by all.
+
+swizzle
+-------
+The [swizzle](./swizzle) directory is a sample implementation of how one might further leverage the [ansible](https://www.ansible.com/) playbooks therein to deploy Kubernetes. As this is a proof of concept, please be aware that this code is subject to change. There is a desire to remove this code once further rigor around kubeadm HA strategies are in place.
 
 development
 -----------
-Vagrant may be used to test ansible playbook development. In this scenario, Vagrant makes use of the ansible provisioner to configure the resulting operating system image. To test all operating systems simultaneously:
+[Vagrant](https://www.vagrantup.com/) may be used to test local ansible playbook development. In this scenario, Vagrant makes use of the ansible provisioner to configure the resulting operating system image. To test all operating systems simultaneously:
 ```
 $ vagrant up
 ```
@@ -21,5 +33,7 @@ You may also selectively test a single operating system as such:
 ```
 $ vagrant up [xenial|centos7]
 ```
+
+To enable verbose ansible logging, you may do so by setting the `WARDROOM_DEBUG` environment variable to `'vvvv'`.
 
 The default Vagrant provisioner is Virtualbox, but other providers are possible by way of the vagrant-mutate plugin.

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,35 @@
+building images
+===============
+Building images for Kubernetes is easily accomplished with the [Packer](https://github.com/hashicorp/packer) and the templates found in this directory.
+
+aws-quickstart
+--------------
+This directory contains the build scripts for the AWS AMI that's used by Heptio's [AWS Quick Start](https://github.com/heptioaws-quickstart). Heptio's AMI is, in turn, built on Ubuntu 16.04 LTS.
+
+prerequisites
+-------------
+To build the AMI, you need:
+
+- [Packer](https://www.packer.io/docs/installation.html)
+- [Ansbile](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.4.0.0
+- An AWS account
+- The AWS CLI installed and configured
+
+build the AMI's
+---------------
+From this directory, simply run:
+
+```
+/path/to/packer build -var-file <YOUR REGION>.json -var kubernetes_version=<YOUR K8S VERSION> -var kubernetes_cni_version=<YOUR K8S CNI VERSION> packer.json
+```
+This will build AMI images in the us-east AWS region (additional region support to follow).
+
+You may limit which images build by adding the `-only=` flag to Packer.
+
+deployment
+----------
+There is a helper script to aid in seeding built AMI's to all other AWS regions:
+
+```
+./deploy-ami.sh -r <SOURCE_REGION> -i <SOURCE_AMI> [-q]
+```

--- a/packer/deploy-ami.sh
+++ b/packer/deploy-ami.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Copyright 2017 by the contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# This script is for after you've run create-ami.sh and want to make the AMI
+# public, and copy it to all AWS regions.
+
+set -o errexit
+set -o pipefail
+
+log_cat() {
+  if [[ "${VERBOSE}" == "true" ]]; then
+    cat 1>&2
+  fi
+}
+
+log() {
+  if [[ "${VERBOSE}" == "true" ]]; then
+    echo $* 1>&2
+  fi
+}
+
+usage() {
+  log "Usage: $0 -r SOURCE_REGION -i SOURCE_AMI [-q]"
+  log_cat 1>&2 <<EOF
+
+Will copy SOURCE_AMI from SOURCE_REGION to all other regions, and will mark the
+image as public in all regions.  This is intended to be run with the AMI that
+packer produces, with the region specified in create-ami.sh
+
+Options:
+	-q: don't output status messages, just the resulting YAML.
+EOF
+}
+
+VERBOSE="true"
+while getopts "r:i:q:" opt; do
+  case $opt in
+    r)
+      SOURCE_REGION=$OPTARG
+      ;;
+    i)
+      SOURCE_AMI=$OPTARG
+      ;;
+    q)
+      VERBOSE=''
+      ;;
+    \?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${SOURCE_REGION}" || -z "${SOURCE_AMI}" ]]; then
+  usage
+  exit 1
+fi
+
+DEST_REGIONS=$(aws ec2 describe-regions --output json | jq -r '.Regions[].RegionName' | grep -v "^${SOURCE_REGION}$")
+AMI_NAME=$(aws ec2 --region "${SOURCE_REGION}" describe-images --image-id "${SOURCE_AMI}" | jq -r '.Images[0].Name')
+test -n "${AMI_NAME}"
+
+# Copy the source AMI into each region, keeping track of what the new ID's are
+REGION_AMIS=("${SOURCE_REGION},${SOURCE_AMI}")
+for RGN in $DEST_REGIONS; do
+  log -n "Copying to ${RGN}..."
+  NEW_AMI=$(
+    aws ec2 copy-image \
+      --source-image-id "${SOURCE_AMI}" \
+      --source-region "${SOURCE_REGION}" \
+      --region "${RGN}" \
+      --name "${AMI_NAME}" \
+      | jq -r '.ImageId'
+  )
+  log $NEW_AMI
+
+  REGION_AMIS+=("${RGN},${NEW_AMI}")
+done
+
+# We do the marking public after we've copied, because it takes a few minutes
+# for them to be available, and this lets AWS do that while we copy the rest.
+log
+log_cat 1>&2 <<EOF
+Marking images as public.  This may take a while!  While you wait, you can
+paste the following into the templates/kubernetes-cluster.template RegionMap to
+use the new AMIs when they're ready:
+EOF
+log
+
+echo "  RegionMap:"
+for STR in "${REGION_AMIS[@]}"; do
+  ARR=(${STR//,/ })
+  
+  
+  cat <<EOF
+    ${ARR[0]}:
+      '64': ${ARR[1]}
+EOF
+done
+log
+
+for STR in "${REGION_AMIS[@]}"; do
+  ARR=(${STR//,/ })
+
+  status_cmd="aws ec2 --region ${ARR[0]} describe-images --image-id ${ARR[1]} | jq -r '.Images[0].State'"
+
+  log -n "Marking ${ARR[1]} in ${ARR[0]} as public..."
+
+  if [[ "$(eval "${status_cmd}")" != "available" ]]; then
+    log -n " waiting for it to be available"
+
+    while [[ "$(eval "${status_cmd}")" != "available" ]]; do
+      log -n "."
+      sleep 5
+    done
+  fi
+
+  aws ec2 --region "${ARR[0]}" modify-image-attribute --image-id "${ARR[1]}" --launch-permission '{"Add":[{"Group":"all"}]}'
+  log "done"
+done

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -7,21 +7,21 @@
   },
   "builders": [
     {
-      "name": "ec2-ubuntu-16.04-{{user `kubernetes_version`}}-{{timestamp}}",
+      "name": "ami-ubuntu-16.04",
       "type": "amazon-ebs",
       "instance_type": "t2.small",
       "source_ami": "{{user `ubuntu_16_04_ami`}}",
-      "ami_name": "ec2-ubuntu-16.04-{{user `kubernetes_version`}}-{{timestamp}}",
+      "ami_name": "ami-ubuntu-16.04-{{user `kubernetes_version`}}-{{timestamp}}",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "ubuntu"
     },
     {
-      "name": "ec2-centos-7.4-{{user `kubernetes_version`}}-{{timestamp}}",
+      "name": "ami-centos-7.4",
       "type": "amazon-ebs",
       "instance_type": "t2.small",
       "source_ami": "{{user `centos_7_4_ami`}}",
-      "ami_name": "ec2-ubuntu-xenial-rhel-{{user `kubernetes_version`}}-{{timestamp}}",
+      "ami_name": "ami-ubuntu-xenial-rhel-{{user `kubernetes_version`}}-{{timestamp}}",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "ssh_username": "centos"
@@ -41,8 +41,8 @@
       "playbook_file": "../ansible/provider.yml",
       "extra_arguments": [ "--extra-vars", "provider=aws" ],
       "only": [
-        "ec2-ubuntu-16.04-{{user `kubernetes_version`}}-{{timestamp}}",
-        "ec2-centos-7.4-{{user `kubernetes_version`}}-{{timestamp}}"
+        "ami-ubuntu-16.04",
+        "ami-centos-7.4"
       ]
     }
   ]


### PR DESCRIPTION
This change provides additional general information about the repo and
how to use it. Nost significantly it adds docs for how to use packer for
building images.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>