### PR TITLE
Upgrade the base AMI's upon build

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+common:
+  upgrade_base: False

--- a/ansible/roles/common/tasks/debian.yml
+++ b/ansible/roles/common/tasks/debian.yml
@@ -4,6 +4,11 @@
     update_cache: True
     cache_valid_time: 3600
 
+- name: perform a dist-upgrade
+  apt:
+    upgrade: dist
+  when: common.upgrade_base is defined and common.upgrade_base|bool == True
+
 - name: install baseline dependencies
   apt:
     name: "{{item}}"

--- a/ansible/roles/common/tasks/redhat.yml
+++ b/ansible/roles/common/tasks/redhat.yml
@@ -7,6 +7,12 @@
     gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
     gpgcheck: true
 
+- name: perform a yum update
+  yum:
+    name: '*'
+    state: latest
+  when: common.upgrade_base is defined and common.upgrade_base|bool == True
+
 - name: install baseline dependencies
   yum:
     name: "{{item}}"

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -54,7 +54,7 @@
       "playbook_file": "../ansible/playbook.yml",
       "extra_arguments": [
         "--extra-vars",
-        "{\"packer\": \"true\", \"kubernetes\": {\"version\": \"{{user `kubernetes_version`}}\", \"cni_version\": \"{{user `kubernetes_cni_version`}}\"}}"
+        "{\"packer\": \"true\", \"common\": {\"upgrade_base\": \"true\" }, \"kubernetes\": {\"version\": \"{{user `kubernetes_version`}}\", \"cni_version\": \"{{user `kubernetes_cni_version`}}\"}}"
       ]
     },
     {


### PR DESCRIPTION
Even though we try to keep the base AMI specifications current, it would
be a good idea to upgrade the packages during image build.  This will
ensure we pick up any packages that have not made it into the stock AMIs
yet.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>