### PR TITLE
Bump AMIs

### DIFF
--- a/packer/us-east-1.json
+++ b/packer/us-east-1.json
@@ -1,4 +1,4 @@
 {
-    "ubuntu_16_04_ami": "ami-3dec9947",
-    "centos_7_4_ami": "ami-ae7bfdb8"
+    "ubuntu_16_04_ami": "ami-41e0b93b",
+    "centos_7_4_ami": "ami-02e98f78"
 }


### PR DESCRIPTION
CentOS: CentOS Linux 7 x86_64 HVM EBS 1708_11.01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-95096eef.4
Ubuntu: ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180109

Signed-off-by: liz <liz@heptio.com>