### PR TITLE
Add packer builder for raw images

### DIFF
--- a/packer/.gitignore
+++ b/packer/.gitignore
@@ -1,0 +1,2 @@
+packer_cache/
+output*/

--- a/packer/README.md
+++ b/packer/README.md
@@ -20,11 +20,19 @@ build the AMI's
 From this directory, simply run:
 
 ```
-/path/to/packer build -var-file <YOUR REGION>.json -var kubernetes_version=<YOUR K8S VERSION> -var kubernetes_cni_version=<YOUR K8S CNI VERSION> -var build_version=`git rev-parse HEAD` packer.json
+$ /path/to/packer build -var-file <YOUR REGION>.json -var kubernetes_version=<YOUR K8S VERSION> -var kubernetes_cni_version=<YOUR K8S CNI VERSION> -var build_version=`git rev-parse HEAD` packer.json
 ```
 This will build AMI images in the us-east AWS region (additional region support to follow).
 
 You may limit which images build by adding the `-only=` flag to Packer.
+
+build raw images
+----------------
+From this directory, run:
+```
+$ cloud-localds cloud.img cloud.cfg
+$ /path/to/packer -var kubernetes_version=<YOUR K8S VERSION> -var kubernetes_cni_version=<YOUR K8S CNI VERSION> -var build_version=`git rev-parse HEAD` packer.json
+```
 
 deployment
 ----------

--- a/packer/cloud.cfg
+++ b/packer/cloud.cfg
@@ -1,0 +1,5 @@
+#cloud-config
+password: ubuntu
+ssh_pwauth: true
+chpasswd:
+  expire: false

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -47,6 +47,31 @@
         "kubernetes_version": "{{user `kubernetes_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_version`}}"
       }
+    },
+    {
+        "name": "raw-ubuntu-16.04",
+        "type": "qemu",
+        "iso_url": "http://mirrors.servercentral.com/ubuntu-cloud-images/xenial/current/xenial-server-cloudimg-amd64-disk1.img",
+        "iso_checksum": "bdfcdcba8c31dba48b5d5482ae922d153a4d46b2",
+        "iso_checksum_type": "sha1",
+        "disk_image": true,
+        "disk_size": 2500,
+        "format": "raw",
+        "headless": true,
+        "disk_compression": true,
+        "ssh_username": "ubuntu",
+        "ssh_password": "ubuntu",
+        "disk_interface": "virtio",
+        "accelerator": "none",
+        "qemuargs": [
+            "-no-kvm",
+            [ "-machine", "pc" ],
+            [ "-m", "2048M" ],
+            ["-smp", "2"],
+            ["-fda", "cloud.img"],
+            ["-serial", "mon:stdio"]
+        ],
+        "vnc_bind_address": "0.0.0.0"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
This builder will build images, in the same manner as other builders,
but with qemu as the "cloud provider."  Right now these are for (large)
raw images, but this could probably be easily evolved into supporting
qcow2.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>