### PR TITLE
Add flannel as a CNI provider

### DIFF
--- a/ansible/roles/kubernetes-cni/defaults/main.yml
+++ b/ansible/roles/kubernetes-cni/defaults/main.yml
@@ -4,3 +4,5 @@ kubernetes_cni:
   calico:
     manifest_url: "https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml"
     calicoctl_url: "https://github.com/projectcalico/calicoctl/releases/download/v1.6.1/calicoctl"
+  flannel:
+    manifest_url: "https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"

--- a/ansible/roles/kubernetes-cni/defaults/main.yml
+++ b/ansible/roles/kubernetes-cni/defaults/main.yml
@@ -5,4 +5,4 @@ kubernetes_cni:
     manifest_url: "https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml"
     calicoctl_url: "https://github.com/projectcalico/calicoctl/releases/download/v1.6.1/calicoctl"
   flannel:
-    manifest_url: "https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"
+    manifest_url: "https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/kube-flannel.yml"

--- a/ansible/roles/kubernetes-cni/tasks/calico.yml
+++ b/ansible/roles/kubernetes-cni/tasks/calico.yml
@@ -9,3 +9,5 @@
      url: "{{ kubernetes_cni.calico.calicoctl_url }}"
      dest: /usr/bin/calicoctl
      mode: 0755
+  retries: 10
+  delay: 5

--- a/ansible/roles/kubernetes-cni/tasks/flannel.yml
+++ b/ansible/roles/kubernetes-cni/tasks/flannel.yml
@@ -1,0 +1,15 @@
+---
+- name: set ipv4 routing
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes
+
+- name: install CNI networking
+  command: "/usr/bin/kubectl apply -f {{ kubernetes_cni.flannel.manifest_url }}"
+  run_once: True
+  delegate_to: "{{ groups['primary_master']|first }}"
+  retries: 10
+  delay: 5

--- a/ansible/roles/kubernetes-cni/tasks/main.yml
+++ b/ansible/roles/kubernetes-cni/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - include_tasks: calico.yml
   when: kubernetes_cni.plugin == "calico"
+
+- include_tasks: flannel.yml
+  when: kubernetes_cni.plugin == "flannel"


### PR DESCRIPTION
As we would like to support flannel in some environments, add this as an
option to the swizzle playbooks.

Also add retries to the calicoctl download, as the default mirror seems
a bit flaky.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>