### PR TITLE
Move hardcoded repo urls to defaults

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -4,3 +4,7 @@ kubernetes:
   cni_version: "0.6.0-00"
   enable_cached_images: False
   cached_images: []
+  apt_key_url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+  apt_repo_string: "deb http://apt.kubernetes.io/ kubernetes-{{ ansible_distribution_release|lower }} main"
+  yum_baseurl: "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64"
+  yum_gpgkey: "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"

--- a/ansible/roles/kubernetes/tasks/debian.yml
+++ b/ansible/roles/kubernetes/tasks/debian.yml
@@ -1,12 +1,12 @@
 ---
 - name: add the kubernetes apt repo key
   apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    url: "{{ kubernetes.apt_key_url }}"
     state: present
 
 - name: add the kubernetes apt repo
   apt_repository:
-    repo: "deb http://apt.kubernetes.io/ kubernetes-{{ ansible_distribution_release|lower }} main"
+    repo: "{{ kubernetes.apt_repo_string }}"
     update_cache: True
     state: present
 

--- a/ansible/roles/kubernetes/tasks/redhat.yml
+++ b/ansible/roles/kubernetes/tasks/redhat.yml
@@ -3,9 +3,9 @@
   yum_repository:
     name: kubernetes
     description: the kubernetes yum repo
-    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+    baseurl: "{{ kubernetes.yum_baseurl }}"
     gpgcheck: True
-    gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+    gpgkey: "{{ kubernetes.yum_gpgkey }}"
 
 - name: install the kubernetes yum packages
   yum:


### PR DESCRIPTION
hardcoding the repo keys and urls is unfriendly to those who may need to
modify these. so, move these to defaults, so that they may be overriden.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>

Addresses #34