### PR TITLE
WIP: Enable controlPlaneEndpoint config for kubeadm

### DIFF
--- a/ansible/roles/kubernetes-master/defaults/main.yml
+++ b/ansible/roles/kubernetes-master/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 kubernetes_master:
   kubeadm_config:
-    kubernetesVersion: 1.8.3
+    kubernetesVersion: 1.9.2
     api:
-      advertiseAddress: "{{ kubernetes_common.api_ip }}"
+      controlPlaneEndpoint: "{{ kubernetes_common.api_fqdn }}"
+      advertiseAddress: "{{ kubernetes_node_ip }}"
     apiServerCertSANs:
     - "{{ kubernetes_common.api_fqdn }}"
     - "{{ kubernetes_common.api_ip }}"
     etcd:
       endpoints: "{{ etcd_client_endpoints }}"
-    token: "{{ generated_token.stdout }}"

--- a/ansible/roles/kubernetes-master/tasks/main.yml
+++ b/ansible/roles/kubernetes-master/tasks/main.yml
@@ -11,15 +11,7 @@
     path: /etc/kubernetes/manifests/kube-apiserver.yaml
   register: kubeadm_apiserver_manifest
 
-- name: generate a kubeadm token
-  command: "/usr/bin/kubeadm token generate"
-  register: generated_token
-  run_once: True
-  delegate_to: "{{ groups['primary_master']|first }}"
-
 - name: drop kubeadm template
-  run_once: True
-  delegate_to: "{{ groups['primary_master']|first }}"
   template:
     src: etc/kubernetes/kubeadm.conf
     dest: /etc/kubernetes/kubeadm.conf
@@ -31,10 +23,15 @@
   run_once: true
   when: kubeadm_apiserver_manifest.stat.exists == False
 
+- name: generate a kubeadm token
+  command: "/usr/bin/kubeadm token create"
+  register: generated_token
+  run_once: True
+  delegate_to: "{{ groups['primary_master']|first }}"
+
 - name: slurp the ca certificate and key
   slurp: src=/etc/kubernetes/{{ item }}
   with_items:
-    - kubeadm.conf
     - pki/apiserver.crt
     - pki/apiserver.key
     - pki/apiserver-kubelet-client.crt

--- a/ansible/roles/kubernetes-node/tasks/main.yml
+++ b/ansible/roles/kubernetes-node/tasks/main.yml
@@ -4,6 +4,10 @@
   register: kube_proxy_running
   ignore_errors: True
 
-- name: join nodes to masters
+- name: join nodes to masters fqdn
+  command: "/usr/bin/kubeadm join {{ kubernetes_common.api_fqdn }}:6443 --token='{{ hostvars[groups['primary_master'][0]]['generated_token']['stdout'] }}' --discovery-token-unsafe-skip-ca-verification"
+  when: kube_proxy_running|failed and ((kubernetes_common.api_fqdn is defined) and (kubernetes_common.api_fqdn != None) and (kubernetes_common.api_fqdn|trim != ''))
+
+- name: join nodes to masters ip
   command: "/usr/bin/kubeadm join {{ kubernetes_common.api_ip }}:6443 --token='{{ hostvars[groups['primary_master'][0]]['generated_token']['stdout'] }}' --discovery-token-unsafe-skip-ca-verification"
-  when: kube_proxy_running|failed
+  when: kube_proxy_running|failed and ((kubernetes_common.api_fqdn is not defined) or (kubernetes_common.api_fqdn == None) or (kubernetes_common.api_fqdn|trim == ''))


### PR DESCRIPTION
controlPlaneEndpoint allows nodes to connect to the control plane using
a resolvable DNS name. This is preferable in cases where an IP cannot be
used.

This is implemented in kubeadm here:
https://github.com/kubernetes/kubernetes/pull/59288

Signed-off-by: Craig Tracey <craigtracey@gmail.com>