### PR TITLE
Added nfs client and jq to default install

### DIFF
--- a/ansible/roles/common/tasks/debian.yml
+++ b/ansible/roles/common/tasks/debian.yml
@@ -22,3 +22,5 @@
     - ebtables
     - socat
     - ntp
+    - jq
+    - nfs-client

--- a/ansible/roles/common/tasks/redhat.yml
+++ b/ansible/roles/common/tasks/redhat.yml
@@ -23,3 +23,5 @@
     - ebtables
     - socat
     - ntp
+    - jq
+    - nfs-utils


### PR DESCRIPTION
This adds `jq` and `nfs-client` to the base OS.

// Fixes #17 

Signed-off-by: Steve Sloka <steves@heptio.com>