### PR TITLE
Support the endpoint-reconciler-type inn 1.9

### DIFF
--- a/ansible/roles/kubernetes-master/defaults/main.yml
+++ b/ansible/roles/kubernetes-master/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
 kubernetes_master:
   kubeadm_config:
-    kubernetesVersion: 1.8.3
+    kubernetesVersion: 1.9.5
     api:
       advertiseAddress: "{{ kubernetes_common.api_ip }}"
+    apiServerExtraArgs:
+      "endpoint-reconciler-type": "lease"
     apiServerCertSANs:
     - "{{ kubernetes_common.api_fqdn }}"
     - "{{ kubernetes_common.api_ip }}"


### PR DESCRIPTION
With multiple masters it is preferrable to the use the
endpoinnt-recons=ciler-type for multi-master situations. Make that a
default.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>