### PR TITLE
Add Vagrant support for multiple providers

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,27 +1,87 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
+# Specify minimum Vagrant version and Vagrant API version
+# The VAGRANTFILE_API_VERSION sets the configuration version (older
+# styles are supported for backwards compatibility). Please don't change
+# it unless you know what you are doing.
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
 
-Vagrant.configure("2") do |config|
+# Require 'yaml' module
+require 'yaml'
 
-  config.vm.define "xenial" do |conf|
-    conf.vm.box = "ubuntu/xenial64"
-    conf.vm.provider "virtualbox" do |v|
-      v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
-    end
-  end
+# Read YAML file with VM details (box, CPU, and RAM)
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'vagrant.yml'))
 
-  config.vm.define "centos7" do |conf|
-    conf.vm.box = "centos/7"
-  end
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "ansible/playbook.yml"
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+    config.vm.define machine['name'] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+
+      # Set machine's hostname
+      srv.vm.hostname = machine['name']
+
+      # Use VMware box by default
+      srv.vm.box = machine['box']['vmw']
+
+      # Configure default synced folder (disable by default)
+      if machine['sync_disabled'] != nil
+        srv.vm.synced_folder '.', '/vagrant', disabled: machine['sync_disabled']
+      else
+        srv.vm.synced_folder '.', '/vagrant', disabled: true
+      end #if machine['sync_disabled']
+
+      # Iterate through networks as per settings in machines.yml
+      machine['nics'].each do |net|
+        if net['ip_addr'] == 'dhcp'
+          srv.vm.network net['type'], type: net['ip_addr']
+        else
+          srv.vm.network net['type'], ip: net['ip_addr']
+        end # if net['ip_addr']
+      end # machine['nics'].each
+
+      # Configure CPU & RAM per settings in machines.yml (Fusion)
+      srv.vm.provider 'vmware_fusion' do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        if machine['nested'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end #if machine['nested']
+      end # srv.vm.provider 'vmware_fusion'
+
+      # Configure CPU & RAM per settings in machines.yml (VirtualBox)
+      srv.vm.provider 'virtualbox' do |vb, override|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
+        override.vm.box = machine['box']['vb']
+        vb.customize ['modifyvm', :id, '--nictype1', 'virtio']
+        vb.customize ['modifyvm', :id, '--nictype2', 'virtio']
+      end # srv.vm.provider 'virtualbox'
+
+      # Configure CPU & RAM per settings in machines.yml (Libvirt)
+      srv.vm.provider 'libvirt' do |lv,override|
+        lv.memory = machine['ram']
+        lv.cpus = machine['vcpu']
+        override.vm.box = machine['box']['lv']
+        if machine['nested'] == true
+          lv.nested = true
+        end # if machine['nested']
+      end # srv.vm.provider 'libvirt'
+    end # config.vm.define
+  end # machines.each
+
+  # Apply Ansible playbook
+  config.vm.provision 'ansible' do |ansible|
+    ansible.playbook = 'ansible/playbook.yml'
     ansible.verbose = ENV['WARDROOM_VERBOSE'] || false
-  end
-
-end
+  end # config.vm.provision
+end # Vagrant.configure

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,0 +1,24 @@
+- box:
+    vmw: "centos/7"
+    vb: "centos/7"
+    lv: "centos/7"
+  name: "centos7"
+  nested: false
+  nics:
+    - type: "private_network"
+      ip_addr: "dhcp"
+  ram: "1024"
+  sync_disabled: true
+  vcpu: "1"
+- box:
+    vmw: "generic/ubuntu1604"
+    vb: "ubuntu/xenial64"
+    lv: "generic/ubuntu1604"
+  name: "xenial"
+  nested: false
+  nics:
+    - type: "private_network"
+      ip_addr: "dhcp"
+  ram: "1024"
+  sync_disabled: true
+  vcpu: "1"


### PR DESCRIPTION
This PR enables users and contributors to use Vagrant with virtualization providers _other_ than VirtualBox. Support for Libvirt and VMware Fusion are in this PR, but this code could be easily extended to support VMware Workstation as well.

This PR does not address the use of other Packer builders. It is only intended to enable the use of additional virtualization providers for local testing of the Ansible playbooks.