### PR TITLE
Only install docker-py when necessary

### DIFF
--- a/ansible/roles/docker/tasks/debian.yml
+++ b/ansible/roles/docker/tasks/debian.yml
@@ -15,7 +15,3 @@
     state: present
   with_items:
     - "docker-ce={{ docker_debian_version }}"
-
-- name: install docker-py
-  pip:
-    name: docker-py

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -25,3 +25,4 @@
 - name: install docker-py
   pip:
     name: docker-py
+  when: kubernetes_enable_cached_images | bool


### PR DESCRIPTION
docker-py is only needed when the user selectively decides to pre-cache
Docker images. So, conditionalize the installation of docker-py based on
whether precached images are specified.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>