### PR TITLE
Add log file limits to the Docker conifguration

### DIFF
--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 docker_debian_version: "{{ docker.debian.version if docker_debian_version_defined else '17.03.2~ce-0~ubuntu-xenial' }}"
 docker_redhat_version: "{{ docker.redhat.version if docker_redhat_version_defined else '17.03.2.ce' }}"
+docker_logging_max_size: 100m

--- a/ansible/roles/docker/templates/etc/docker/daemon.json
+++ b/ansible/roles/docker/templates/etc/docker/daemon.json
@@ -1,4 +1,9 @@
 {
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "{{ docker_logging_max_size }}"
+  },
   "storage-driver": "overlay2"{% if ansible_os_family|lower == "redhat" %},
   "storage-opts": [
     "overlay2.override_kernel_check=true"


### PR DESCRIPTION
By default there is no limit the size of a container log. Docker
supports limiting the log file to a particular size, and this change
simply enables this feature. Note that this is a truncate and not a
rotate.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>