### PR TITLE
Move packages from the common tasks to defaults

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,2 +1,25 @@
 ---
 common_upgrade_base: "{{ common.upgrade_base if common_upgrade_base_defined else False }}"
+common_rpms:
+- yum-utils
+- python2-pip
+- python-requests
+- ebtables
+-  socat
+- ntp
+- jq
+- nfs-utils
+common_extra_rpms: []
+common_debs:
+- openssh-client
+- openssh-server
+- apt-transport-https
+- python-pip
+- python-requests
+- ebtables
+- socat
+- ntp
+- jq
+- nfs-client
+common_extra_debs: []
+common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/ansible/roles/common/tasks/debian.yml
+++ b/ansible/roles/common/tasks/debian.yml
@@ -11,16 +11,12 @@
 
 - name: install baseline dependencies
   apt:
-    name: "{{item}}"
+    name: "{{ item }}"
     state: latest
-  with_items:
-    - openssh-client
-    - openssh-server
-    - apt-transport-https
-    - python-pip
-    - python-requests
-    - ebtables
-    - socat
-    - ntp
-    - jq
-    - nfs-client
+  with_items: "{{ common_debs }}"
+
+- name: install extra debs
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ common_extra_debs }}"

--- a/ansible/roles/common/tasks/redhat.yml
+++ b/ansible/roles/common/tasks/redhat.yml
@@ -1,11 +1,7 @@
 ---
 - name: add epel repo
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
-    gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
-    gpgcheck: true
+  yum:
+    name: "{{ common_redhat_epel_rpm }}"
 
 - name: perform a yum update
   yum:
@@ -15,13 +11,10 @@
 
 - name: install baseline dependencies
   yum:
-    name: "{{item}}"
-  with_items:
-    - yum-utils
-    - python-pip
-    - python-requests
-    - ebtables
-    - socat
-    - ntp
-    - jq
-    - nfs-utils
+    name: "{{ item }}"
+  with_items: "{{ common_rpms }}"
+
+- name: install extra rpms
+  yum:
+    name: "{{ item }}"
+  with_items: "{{ common_extra_rpms }}"


### PR DESCRIPTION
Instead of hardcoding the packages in the common tasks themselves, move
them to the defaults for the common role. This allows them to be
modified selectively during configuration.

Introduce the "extra" packages concept where users may include
additional packages over top of the reauired set.

Fix the install of EPEL to install the rpm from over the wire.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>