### PR TITLE
Parameterize the kube-ucarp-vip role

### DIFF
--- a/ansible/roles/kube-ucarp-vip/defaults/main.yaml
+++ b/ansible/roles/kube-ucarp-vip/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+kube_ucarp_vip_vid: 41
+kube_ucarp_vip_address: 10.10.10.3/24
+kube_ucarp_vip_password: mypassword
+kube_ucarp_vip_interface: enp0s8

--- a/ansible/roles/kube-ucarp-vip/templates/etc/kubernetes/manifests/kube-ucarp-vip.yaml
+++ b/ansible/roles/kube-ucarp-vip/templates/etc/kubernetes/manifests/kube-ucarp-vip.yaml
@@ -13,10 +13,10 @@ spec:
       privileged: true
     env:
     - name: UCARP_VID
-      value: "41"
+      value: "{{ kube_ucarp_vip_vid }}"
     - name: UCARP_ADDRESS
-      value: "10.10.10.3/24"
+      value: "{{ kube_ucarp_vip_address }}"
     - name: UCARP_PASSWORD
-      value: "mypassword"
+      value: "{{ kube_ucarp_vip_password }}"
     - name: UCARP_DEVICE
-      value: "enp0s8"
+      value: "{{ kube_ucarp_vip_interface }}"


### PR DESCRIPTION
Even though this is meant for reference only, dont hardcode values into
the kub-ucarp-vip role. Make the values configurable parameters so that
they may be overidden.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>