### PR TITLE
Update common role to fix intermittent /proc/sys/net/bridge/bridge-nf-call-iptables errors

### DIFF
--- a/ansible/roles/common/tasks/redhat.yml
+++ b/ansible/roles/common/tasks/redhat.yml
@@ -18,3 +18,16 @@
   yum:
     name: "{{ item }}"
   with_items: "{{ common_extra_rpms }}"
+
+- name: Load br_netfilter kernel module
+  modprobe:
+    name: br_netfilter
+    state: present
+
+- name: Set sys.net.bridge.bridge-nf-call-iptables
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes


### PR DESCRIPTION
Per #74, CentOS AMIs without this setting will intermittently fail when running `kubeadm`. This PR updates the "common" Ansible role to ensure that `net.bridge.bridge-nf-call-iptables` is correctly set to 1.

Closes #74.