### PR TITLE
Add variable file for AWS us-west-2 region

### DIFF
--- a/packer/us-west-2.json
+++ b/packer/us-west-2.json
@@ -1,0 +1,4 @@
+{
+    "ubuntu_16_04_ami": "ami-51e99c29",
+    "centos_7_4_ami": "ami-02c71d7a"
+}

--- a/packer/us-west-2.json
+++ b/packer/us-west-2.json
@@ -1,4 +1,4 @@
 {
-    "ubuntu_16_04_ami": "ami-51e99c29",
-    "centos_7_4_ami": "ami-02c71d7a"
+    "ubuntu_16_04_ami": "ami-b53c6acd",
+    "centos_7_4_ami": "ami-19007261"
 }


### PR DESCRIPTION
This PR adds a Packer variable file for the AWS us-west-2 region, allowing Wardroom to build AMIs in us-west-2 as well as us-east-1.