### PR TITLE
Fix Docker CE 17.03.x installation

### DIFF
--- a/ansible/roles/docker/tasks/redhat.yml
+++ b/ansible/roles/docker/tasks/redhat.yml
@@ -14,22 +14,17 @@
     gpgkey: https://download.docker.com/linux/centos/gpg
     gpgcheck: true
 
+# This task is here to help w/ idempotence for next task
+# Can be removed if/when the playbook moves back to using yum module
 - name: determine if docker binary is present (implies Docker is installed)
   stat:
     path: /usr/bin/docker
   register: docker_present
 
+# Using this approach because of https://github.com/moby/moby/issues/33930
 - name: install Docker CE if docker binary is not present
   command: "yum install -y --setopt=obsoletes=0 docker-ce-selinux-{{docker_redhat_version}} docker-ce-{{docker_redhat_version}}"
   when: docker_present.stat.exists == False
-
-#- name: install docker
-#  yum:
-#    name: "{{ item }}"
-#    state: present
-#    allow_downgrade: True
-#  with_items:
-#    - "docker-ce-selinux-{{docker_redhat_version}}"
 
 - name: start docker service
   service:

--- a/ansible/roles/docker/tasks/redhat.yml
+++ b/ansible/roles/docker/tasks/redhat.yml
@@ -14,13 +14,22 @@
     gpgkey: https://download.docker.com/linux/centos/gpg
     gpgcheck: true
 
-- name: install docker
-  yum:
-    name: "{{ item }}"
-    state: present
-    allow_downgrade: True
-  with_items:
-    - "docker-ce-selinux-{{docker_redhat_version}}"
+- name: determine if docker binary is present (implies Docker is installed)
+  stat:
+    path: /usr/bin/docker
+  register: docker_present
+
+- name: install Docker CE if docker binary is not present
+  command: "yum install -y --setopt=obsoletes=0 docker-ce-selinux-{{docker_redhat_version}} docker-ce-{{docker_redhat_version}}"
+  when: docker_present.stat.exists == False
+
+#- name: install docker
+#  yum:
+#    name: "{{ item }}"
+#    state: present
+#    allow_downgrade: True
+#  with_items:
+#    - "docker-ce-selinux-{{docker_redhat_version}}"
 
 - name: start docker service
   service:


### PR DESCRIPTION
Due to issues with some dependencies, Docker CE 17.03 installation on CentOS/RHEL 7 can't be accomplished using standard `yum` module. This PR fixes the installation by using a `command` module to run `yum` directly.

Addresses issue #72 (see conversation there for links to dependencies issues referenced above).