### PR TITLE
Make the python preinstall more DRY

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,20 +1,13 @@
 ---
-- hosts: all
-  gather_facts: false
-  become: yes
-  pre_tasks:
-  - name: install python
-    raw: bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qqy python python-pip)"
-    register: output
-    changed_when: output.stdout != ""
+- import_playbook: pre.yml
 
 - name: build image
   hosts: all
   become: yes
   roles:
-    - role: common
-    - role: docker
-    - role: kubernetes
-    - role: providers
-    - role: packer-cleanup
-      when: packer_build_name is defined
+  - role: common
+  - role: docker
+  - role: kubernetes
+  - role: providers
+  - role: packer-cleanup
+    when: packer_build_name is defined

--- a/ansible/pre.yml
+++ b/ansible/pre.yml
@@ -4,6 +4,6 @@
   become: yes
   pre_tasks:
   - name: install python
-    raw: bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qqy python python-pip)"
+    raw: bash -c "if grep -qi debian /etc/os-release && [ ! -e /usr/bin/python ]; then apt -qqy update; apt install -qqy python python-pip; fi;"
     register: output
     changed_when: output.stdout != ""


### PR DESCRIPTION
Right now we have the same code for installing python in two different
places. Additionally, this code assumes Debian based systems. So, clean
this up so that it only applies to Debian systems, and such that it is
consolidated in `pre.yml`

Signed-off-by: Craig Tracey <craigtracey@gmail.com>