### PR TITLE
Add support for building OCI images

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -145,6 +145,22 @@ compute.subnetworks.useExternalIp
 compute.zones.get
 ```
 
+### Building Oracle Cloud Infrastructure (OCI) Images
+
+Building Oracle Cloud Infrastructure (OCI) images requires a correct configuration for the Oracle CLI as outlined in the "CLI Configuration Information" section of [this page](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm), althoug the Oracle CLI does not need to be installed (Packer will use the values in the configuration file).
+
+You will also need the following pieces of information:
+
+* The Oracle Cloud ID (OCID) of the compartment where the build VM will be instantiated (you can use the root compartment, whose OCID is equal to the tenancy OCID)
+* The name of the availability domain where the build VM will be instantiated
+* The OCID for the subnet that corresponds to the availability domain where the build VM will be instantiated
+
+To build an OCI image:
+
+```sh
+packer build -var-file oci-us-phoenix-1.json -var build_version=`git rev-parse HEAD` -var oci_availability_domain="<name of availability domain>" -var oci_compartment_ocid="<OCID of compartment>" -var oci_subnet_ocid="<OCID of subnet in specified availability domain>" -only=oci-ubuntu packer.json
+```
+
 ## Testing Images
 
 Connect remotely to an instance created from the image and run the Node Conformance tests using the following commands:

--- a/packer/oci-us-phoenix-1.json
+++ b/packer/oci-us-phoenix-1.json
@@ -1,0 +1,3 @@
+{
+    "oci_base_image_ocid": "ocid1.image.oc1.phx.aaaaaaaab6bbszpshh7fy6aw2ay74rhoiuu4g2nmzr6ykcwt53ekadzjp2ta"
+}

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -83,6 +83,27 @@
         "kubernetes_version": "{{user `kubernetes_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_version`}}"
       }
+    },
+    {
+      "name": "oci-ubuntu",
+      "type": "oracle-oci",
+      "availability_domain": "{{ user `oci_availability_domain` }}",
+      "base_image_ocid": "{{ user `oci_base_image_ocid` }}",
+      "compartment_ocid": "{{ user `oci_compartment_ocid` }}",
+      "image_name": "Canonical-Ubuntu-16.04-K8s-{{ user `kubernetes_version` }}-{{ timestamp }}",
+      "shape": "VM.Standard1.1",
+      "ssh_username": "ubuntu",
+      "subnet_ocid": "{{ user `oci_subnet_ocid` }}",
+      "tags": {
+        "build_version": "{{ user `build_version` }}",
+        "source_ami": "{{ user `oci_base_image_ocid` }}",
+        "build_date": "{{ isotime }}",
+        "distribution": "Ubuntu",
+        "distribution_release": "xenial",
+        "distribution_version": "16.04",
+        "kubernetes_version": "{{ user `kubernetes_version` }}",
+        "kubernetes_cni_version": "{{ user `kubernetes_cni_version` }}"
+      }
     }
   ],
   "provisioners": [


### PR DESCRIPTION
This PR adds support for building Oracle Cloud Infrastructure (OCI) images via Wardroom. This PR makes the following changes:

1. Adds an "oracle-oci" builder to `packer.json`
2. Adds a variable file (`oci-us-phoenix-1.json`) that provides the base image OCID
3. Adds content to `packer/README.md` with instructions on building OCI images

For reliable image builds on OCI, a change to `ansible/playbook.yml` to add retries to the Debian/Ubuntu Python installation is needed; we believe this to be due to less-than-reliable `apt` mirrors hosted by Oracle. I'm holding those changes in a separate branch until #93 is resolved. Otherwise, this PR should be ready to merge.