### PR TITLE
Add retries to Python 2 pre-install task

### DIFF
--- a/ansible/pre.yml
+++ b/ansible/pre.yml
@@ -7,3 +7,6 @@
     raw: bash -c "if grep -qi debian /etc/os-release && [ ! -e /usr/bin/python ]; then apt -qqy update; apt install -qqy python python-pip; fi;"
     register: output
     changed_when: output.stdout != ""
+    retries: 3
+    delay: 3
+    until: output.rc == 0


### PR DESCRIPTION
This PR adds retries to the Debian-specific Python 2 installation pre-task. This helps address timeouts due to flaky cloud repositories that may not respond in a timely fashion.

This is related to PR #95.