### PR TITLE
Add kubelet cgroup driver default

### DIFF
--- a/ansible/roles/kubernetes-common/defaults/main.yml
+++ b/ansible/roles/kubernetes-common/defaults/main.yml
@@ -4,4 +4,5 @@ kubernetes_common_api_ip: 10.10.10.3
 kubernetes_common_primary_interface: enp0s8
 
 # kubelet_extra_args is a dict of arg:value (ie. 'node-ip: 1.1.1.1' for '--node-ip=1.1.1.1')
-kubernetes_common_kubelet_extra_args: {}
+kubernetes_common_kubelet_extra_args:
+  cgroup-driver: systemd


### PR DESCRIPTION
This change adds systemd as the kubelet's default cgroup driver which
matches how docker is being configured.

For reference to docker config: https://github.com/heptiolabs/wardroom/blob/master/ansible/roles/docker/templates/etc/docker/daemon.json#L2