### PR TITLE
Add extra Packer cleanup tasks

### DIFF
--- a/ansible/roles/packer-cleanup/tasks/main.yml
+++ b/ansible/roles/packer-cleanup/tasks/main.yml
@@ -15,3 +15,24 @@
   file:
     dest: /etc/machine-id
     state: touch
+
+- name: Clean up extraneous /etc/hosts entries
+  lineinfile:
+    path: /etc/hosts
+    state: absent
+    regexp: '^127\.0\.1\.1.*instance.*'
+
+- name: Check for saved iptables configuration
+  stat:
+    path: /etc/iptables/rules.v4
+  register: iptablescfg
+
+- name: Remove overly restrictive iptables rules if saved configuration exists
+  lineinfile:
+    path: /etc/iptables/rules.v4
+    state: absent
+    regexp: "{{ item }}"
+  with_items:
+    - "^-A INPUT -j REJECT --reject-with icmp-host-prohibited$"
+    - "^-A FORWARD -j REJECT --reject-with icmp-host-prohibited$"
+  when: iptablescfg.stat.exists == True


### PR DESCRIPTION
This PR add some Ansible tasks to the "packer-cleanup" role to remove extra /etc/hosts entries and clean up restrictive iptables rules. These clean-up tasks are primary targeting OCI builds. I tested these additional tasks against OCI (Ubuntu), AWS (Ubuntu), and AWS (CentOS), and saw no ill effects to the image build process as a result of adding them (nor were any ill effects observed in instances created on AWS with these changes in place). The changes _do_ work for OCI builds.