### PR TITLE
Pass package list directly to yum/apt module instead of using with_items

### DIFF
--- a/ansible/roles/common/tasks/debian.yml
+++ b/ansible/roles/common/tasks/debian.yml
@@ -11,12 +11,10 @@
 
 - name: install baseline dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ common_debs }}"
     state: latest
-  with_items: "{{ common_debs }}"
 
 - name: install extra debs
   apt:
-    name: "{{ item }}"
+    name: "{{ common_extra_debs }}"
     state: latest
-  with_items: "{{ common_extra_debs }}"

--- a/ansible/roles/common/tasks/redhat.yml
+++ b/ansible/roles/common/tasks/redhat.yml
@@ -11,13 +11,11 @@
 
 - name: install baseline dependencies
   yum:
-    name: "{{ item }}"
-  with_items: "{{ common_rpms }}"
+    name: "{{ common_rpms }}"
 
 - name: install extra rpms
   yum:
-    name: "{{ item }}"
-  with_items: "{{ common_extra_rpms }}"
+    name: "{{ common_extra_rpms }}"
 
 - name: load br_netfilter kernel module
   modprobe:

--- a/ansible/roles/docker/tasks/debian.yml
+++ b/ansible/roles/docker/tasks/debian.yml
@@ -11,10 +11,8 @@
 
 - name: install docker
   apt:
-    name: "{{ item }}"
+    name: "docker-ce={{ docker_debian_version }}"
     state: present
-  with_items:
-    - "docker-ce={{ docker_debian_version }}"
 
 - name: install docker-py
   pip:

--- a/ansible/roles/docker/tasks/redhat.yml
+++ b/ansible/roles/docker/tasks/redhat.yml
@@ -1,10 +1,9 @@
 ---
 - name: add docker dependencies
   yum:
-    name: "{{ item }}"
-  with_items:
-    - device-mapper-persistent-data
-    - lvm2
+    name: 
+      - device-mapper-persistent-data
+      - lvm2
 
 - name: add docker repo
   yum_repository:

--- a/ansible/roles/kubernetes/tasks/debian.yml
+++ b/ansible/roles/kubernetes/tasks/debian.yml
@@ -12,9 +12,8 @@
 
 - name: install kubernetes packages
   apt:
-    name: "{{ item }}"
-  with_items:
-    - "kubelet={{ kubernetes_version | kube_platform_version('debian') }}"
-    - "kubeadm={{ kubernetes_version | kube_platform_version('debian') }}"
-    - "kubectl={{ kubernetes_version | kube_platform_version('debian') }}"
-    - "kubernetes-cni={{kubernetes_cni_version | kube_platform_version('debian') }}"
+    name: 
+      - "kubelet={{ kubernetes_version | kube_platform_version('debian') }}"
+      - "kubeadm={{ kubernetes_version | kube_platform_version('debian') }}"
+      - "kubectl={{ kubernetes_version | kube_platform_version('debian') }}"
+      - "kubernetes-cni={{kubernetes_cni_version | kube_platform_version('debian') }}"

--- a/ansible/roles/kubernetes/tasks/redhat.yml
+++ b/ansible/roles/kubernetes/tasks/redhat.yml
@@ -9,10 +9,9 @@
 
 - name: install the kubernetes yum packages
   yum:
-    name: "{{ item }}"
     allow_downgrade: True
-  with_items:
-    - "kubelet-{{ kubernetes_version | kube_platform_version('redhat') }}"
-    - "kubeadm-{{ kubernetes_version | kube_platform_version('redhat') }}"
-    - "kubectl-{{ kubernetes_version | kube_platform_version('redhat') }}"
-    - "kubernetes-cni-{{kubernetes_cni_version | kube_platform_version('redhat')}}"
+    name:
+      - "kubelet-{{ kubernetes_version | kube_platform_version('redhat') }}"
+      - "kubeadm-{{ kubernetes_version | kube_platform_version('redhat') }}"
+      - "kubectl-{{ kubernetes_version | kube_platform_version('redhat') }}"
+      - "kubernetes-cni-{{kubernetes_cni_version | kube_platform_version('redhat')}}"


### PR DESCRIPTION
Fixes #111 

Both the yum and apt Ansible modules support passing a list of packages.

This is more efficient than processing each pacakge individually, which
is what happens when using 'with_items'.

Yum module docs:
>  To operate on several packages this can accept a comma separated string of packages or (as of 2.0) a list of packages.

Apt module docs:
> A list of package names, like foo, or package specifier with version, like foo=1.0. Name wildcards (fnmatch) like apt* and version wildcards like foo=1.0* are also supported.