### PR TITLE
[swizzle] Don't install kubernetes packages on etcd nodes

### DIFF
--- a/swizzle/swizzle.yml
+++ b/swizzle/swizzle.yml
@@ -6,7 +6,7 @@
     - ansible-prereqs
 
 - name: install kubernetes prerequisites
-  hosts: all
+  hosts: all:!etcd
   become: yes
   roles:
     - common


### PR DESCRIPTION
Etcd is running as a systemd service, so there's no need for docker or
kubernetes on the etcd nodes.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>