### PR TITLE
Update dependencies

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -5,11 +5,12 @@ common_rpms:
 - python2-pip
 - python-requests
 - ebtables
--  socat
+- socat
 - ntp
 - jq
 - nfs-utils
 - cloud-utils
+- bind-utils
 common_extra_rpms: []
 common_debs:
 - openssh-client
@@ -23,5 +24,6 @@ common_debs:
 - jq
 - nfs-client
 - cloud-utils
+- dnsutils
 common_extra_debs: []
 common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"


### PR DESCRIPTION
dig was not included but is now required by aws-quickstart.

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>