### PR TITLE
Add variables file for AWS us-east-2

### DIFF
--- a/packer/aws-us-east-2.json
+++ b/packer/aws-us-east-2.json
@@ -1,0 +1,5 @@
+{
+    "ubuntu_18_04_ami": "ami-0c55b159cbfafe1f0",
+    "centos_7_4_ami": "ami-08b08d6d",
+    "aws_region": "us-east-2"
+}


### PR DESCRIPTION
This PR adds a variables file for the "us-east-2" region on AWS. The variables file properly sets the `aws_region` variable to workaround issue #123.