### PR TITLE
Add back Ubuntu 16.04 support

### DIFF
--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -2,4 +2,4 @@
 docker_debian_version: "{{ docker.debian.version if docker_debian_version_defined else '5:18.09.1~3-0~ubuntu-bionic' }}"
 docker_redhat_version: "{{ docker.redhat.version if docker_redhat_version_defined else '17.03.2.ce' }}"
 docker_logging_max_size: 100m
-docker_xenial_version: "17.03.2~ce-0~ubuntu-xenial"
+docker_xenial_version: "18.06.3~ce~3-0~ubuntu"

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -2,3 +2,4 @@
 docker_debian_version: "{{ docker.debian.version if docker_debian_version_defined else '5:18.09.1~3-0~ubuntu-bionic' }}"
 docker_redhat_version: "{{ docker.redhat.version if docker_redhat_version_defined else '17.03.2.ce' }}"
 docker_logging_max_size: 100m
+docker_xenial_version: "17.03.2~ce-0~ubuntu-xenial"

--- a/ansible/roles/docker/tasks/debian.yml
+++ b/ansible/roles/docker/tasks/debian.yml
@@ -9,12 +9,21 @@
     repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower}} {{ ansible_distribution_release|lower }} stable"
     update_cache: true
 
-- name: install docker
+- name: install Docker CE (Ubuntu Bionic only)
   apt:
     name: "{{ item }}"
     state: present
   with_items:
     - "docker-ce={{ docker_debian_version }}"
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic'
+
+- name: Install Docker CE (Ubuntu Xenial only)
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "docker-ce={{ docker_xenial_version }}"
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
 
 - name: install docker-py
   pip:

--- a/ansible/roles/docker/tasks/debian.yml
+++ b/ansible/roles/docker/tasks/debian.yml
@@ -9,21 +9,12 @@
     repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower}} {{ ansible_distribution_release|lower }} stable"
     update_cache: true
 
-- name: install Docker CE (Ubuntu Bionic only)
+- name: install Docker CE
   apt:
     name: "{{ item }}"
     state: present
   with_items:
-    - "docker-ce={{ docker_debian_version }}"
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic'
-
-- name: Install Docker CE (Ubuntu Xenial only)
-  apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "docker-ce={{ docker_xenial_version }}"
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
+    - "docker-ce={{ docker_xenial_version if ansible_distribution_release == 'xenial' else docker_debian_version }}"
 
 - name: install docker-py
   pip:

--- a/packer/aws-us-east-1.json
+++ b/packer/aws-us-east-1.json
@@ -1,4 +1,6 @@
 {
+    "ubuntu_16_04_ami": "ami-0565af6e282977273",
     "ubuntu_18_04_ami": "ami-034920e38d95c9311",
-    "centos_7_4_ami": "ami-b81dbfc5"
+    "centos_7_4_ami": "ami-b81dbfc5",
+    "aws_region": "us-east-1"
 }

--- a/packer/aws-us-west-2.json
+++ b/packer/aws-us-west-2.json
@@ -1,4 +1,6 @@
 {
+    "ubuntu_16_04_ami": "ami-08692d171e3cf02d6",
     "ubuntu_18_04_ami": "ami-023119b698e71c162",
-    "centos_7_4_ami": "ami-19007261"
+    "centos_7_4_ami": "ami-19007261",
+    "aws_region": "us-west-2"
 }

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -31,6 +31,27 @@
       }
     },
     {
+      "name": "ami-ubuntu-1604",
+      "type": "amazon-ebs",
+      "instance_type": "t2.small",
+      "source_ami": "{{user `ubuntu_16_04_ami`}}",
+      "ami_name": "ami-ubuntu-16.04-{{user `kubernetes_version`}}-{{timestamp}}",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "region": "{{user `aws_region`}}",
+      "ssh_username": "ubuntu",
+      "tags": {
+        "build_version": "{{user `build_version`}}",
+        "source_ami": "{{user `ubuntu_16_04_ami`}}",
+        "build_date": "{{isotime}}",
+        "distribution": "Ubuntu",
+        "distribution_release": "xenial",
+        "distribution_version": "16.04",
+        "kubernetes_version": "{{user `kubernetes_version`}}",
+        "kubernetes_cni_version": "{{user `kubernetes_cni_version`}}"
+      }
+    },
+    {
       "name": "ami-centos",
       "type": "amazon-ebs",
       "instance_type": "t2.small",


### PR DESCRIPTION
This PR returns Ubuntu 16.04 support to Wardroom. The `aws-us-east-1.json` and `aws-us-west-2.json` variable files have been updated to add an Ubuntu 16.04 AMI variable, and have been updated with `aws_region` to work around #123.

The Ansible `docker` role was updated to allow for different Docker versions on 16.04 versus 18.04.

These changes were tested by successfully building AMIs for both 16.04 and 18.04 with Kubernetes 1.11.7, 1.12.5, and 1.13.2 (all three versions on both 16.04 and 18.04). All builds completed successfully with no errors.