### PR TITLE
Add Ubuntu 16.04 AMI to us-east-2 variables file

### DIFF
--- a/packer/aws-us-east-2.json
+++ b/packer/aws-us-east-2.json
@@ -1,4 +1,5 @@
 {
+    "ubuntu_16_04_ami": "ami-0e7589a8422e3270f",
     "ubuntu_18_04_ami": "ami-0c55b159cbfafe1f0",
     "centos_7_4_ami": "ami-08b08d6d",
     "aws_region": "us-east-2"


### PR DESCRIPTION
This PR adds the value for Ubuntu 16.04 AMI ID to the variables file for us-east-2. Apparently this value was missed in PR #125.