### PR TITLE
[WIP] Add image testing using goss

### DIFF
--- a/packer/goss.yaml
+++ b/packer/goss.yaml
@@ -1,0 +1,20 @@
+package:
+  docker-ce:
+    installed: true
+    versions:
+    - 5:18.09.1~3-0~ubuntu-bionic
+  kubeadm:
+    installed: true
+    versions:
+    - 1.13.2-00
+  kubectl:
+    installed: true
+    versions:
+    - 1.13.2-00
+  kubelet:
+    installed: true
+    versions:
+    - 1.13.2-00
+mount:
+  swap:
+    exists: false

--- a/packer/goss/1.11.7-00.yaml
+++ b/packer/goss/1.11.7-00.yaml
@@ -1,0 +1,2 @@
+k8s_version: 1.11.7-00
+docker_version: 18.06.3-ce-3-0~ubuntu

--- a/packer/goss/1.12.5-00.yaml
+++ b/packer/goss/1.12.5-00.yaml
@@ -1,0 +1,2 @@
+k8s_version: 1.12.5-00
+docker_version: 18.06.3-ce-3-0~ubuntu

--- a/packer/goss/1.13.2-00.yaml
+++ b/packer/goss/1.13.2-00.yaml
@@ -1,0 +1,2 @@
+k8s_version: 1.13.2-00
+docker_version: 5:18.09.1~3-0~ubuntu-bionic

--- a/packer/goss/goss.yaml
+++ b/packer/goss/goss.yaml
@@ -2,19 +2,19 @@ package:
   docker-ce:
     installed: true
     versions:
-    - 5:18.09.1~3-0~ubuntu-bionic
+    - {{ .Vars.docker_version }}
   kubeadm:
     installed: true
     versions:
-    - 1.13.2-00
+    - {{ .Vars.k8s_version }}
   kubectl:
     installed: true
     versions:
-    - 1.13.2-00
+    - {{ .Vars.k8s_version }}
   kubelet:
     installed: true
     versions:
-    - 1.13.2-00
+    - {{ .Vars.k8s_version }}
 mount:
   swap:
     exists: false

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -145,8 +145,9 @@
     {
       "type": "goss",
       "tests": [
-        "goss.yaml"
-      ]
+        "goss/goss.yaml"
+      ],
+      "vars_file": "goss/{{user `kubernetes_version`}}.yaml"
     }
   ]
 }

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -141,6 +141,12 @@
         "--extra-vars",
         "common_upgrade_base=true kubernetes_version={{user `kubernetes_version`}} kubernetes_cni_version={{user `kubernetes_cni_version`}}"
       ]
+    },
+    {
+      "type": "goss",
+      "tests": [
+        "goss.yaml"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds image testing using `goss` to Wardroom. `goss` image testing is integrated into the Packer build process via the packer-provisioner-goss plugin (https://github.com/YaleUniversity/packer-provisioner-goss). The `goss` YAML file is templated for support of different K8s/Docker CE versions.

*The code is complete and has undergone limited testing. It needs more extensive testing before being ready to merge.*

This PR closes issue #122.