### PR TITLE
Update/add us west 1

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -163,8 +163,8 @@ packer build -var-file oci-us-phoenix-1.json -var build_version=`git rev-parse H
 
 ## Testing Images
 
-After our images are created, we want to prove that the images can be used to build conformant clusters. The conformance testing suite tests clusters, not single nodes -- so we have to spin up a single node cluster
-and run the tests inside that cluster.
+After your images are created, you'll want to prove that the images can be used to build conformant clusters. The conformance testing suite tests _clusters_, not single nodes -- so we have to spin up a single node cluster
+and run the tests inside the new cluster.
 
 Connect remotely to an instance created from the image and run the Node Conformance tests using the following commands:
 

--- a/packer/README.md
+++ b/packer/README.md
@@ -169,6 +169,8 @@ and run the tests inside that cluster.
 Connect remotely to an instance created from the image and run the Node Conformance tests using the following commands:
 
 ```sh
+
+# Cluster Creation (skip this if you create a single node cluster in some other way)
 sudo kubeadm init --pod-network-cidr=192.168.0.0/16
 sudo chown $(id -u):$(id -g) /etc/kubernetes/admin.conf
 export KUBECONFIG=/etc/kubernetes/admin.conf
@@ -178,6 +180,7 @@ kubectl create -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes
 kubectl create -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
 
 
+# Setup for Conformance tests
 # Remove all the taints from the node -- simply adding tolerations to the conformance deployment didn't work
 kubectl patch nodes $(hostname) -p '{"spec":{"taints":[]}}'
 

--- a/packer/README.md
+++ b/packer/README.md
@@ -163,13 +163,42 @@ packer build -var-file oci-us-phoenix-1.json -var build_version=`git rev-parse H
 
 ## Testing Images
 
+After our images are created, we want to prove that the images can be used to build conformant clusters. The conformance testing suite tests clusters, not single nodes -- so we have to spin up a single node cluster
+and run the tests inside that cluster.
+
 Connect remotely to an instance created from the image and run the Node Conformance tests using the following commands:
 
 ```sh
-wget https://dl.k8s.io/$(< /etc/kubernetes_community_ami_version)/kubernetes-test.tar.gz
-tar -zxvf kubernetes-test.tar.gz kubernetes/platforms/linux/amd64
-cd kubernetes/platforms/linux/amd64
-sudo ./ginkgo --nodes=8 --flakeAttempts=2 --focus="\[Conformance\]" --skip="\[Flaky\]|\[Serial\]|\[sig-network\]|Container Lifecycle Hook" ./e2e_node.test -- --k8s-bin-dir=/usr/bin
+sudo kubeadm init --pod-network-cidr=192.168.0.0/16
+sudo chown $(id -u):$(id -g) /etc/kubernetes/admin.conf
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+
+kubectl create -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+kubectl create -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+
+
+# Remove all the taints from the node -- simply adding tolerations to the conformance deployment didn't work
+kubectl patch nodes $(hostname) -p '{"spec":{"taints":[]}}'
+
+# Get the yaml to run the conformance tests, and replace the source image repo to use the 
+# globally accessible image repo, instead of the Kubernetes internal one.
+# This yaml was created along with the 1.14 release, but can be used with 1.13, and 
+# it will up updated with future releases. (Again, this only works >=1.13)
+wget https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/conformance/conformance-e2e.yaml
+sed -i 's/k8s.gcr.io/gcr.io\/google-containers/' conformance-e2e.yaml
+
+# Will also need to go in and update the version number of the image to add the trailing "patch version" part
+# The pulled yaml will only have major.minor.
+# So, for example, with v1.14, you'll need to update the image to 1.14.0
+# The valid conformance test images can be found here:
+# gcr.io/google-containers/conformance-amd64
+
+# Add to "value" for E2E_SKIP env var
+\\[Flaky\\]|\\[Serial\\]|\\[sig-network\\]|Container Lifecycle Hook
+
+# Finally, run the tests -- and leave it alone for about an hour.
+kubectl create -f conformance-e2e.yaml
 ```
 
 ## Deploying Images

--- a/packer/aws-us-west-1.json
+++ b/packer/aws-us-west-1.json
@@ -1,0 +1,6 @@
+{
+    "ubuntu_16_04_ami": "ami-9cb2bdfc",
+    "ubuntu_18_04_ami": "ami-0ea0e2d21f93aa6c9",
+    "centos_7_4_ami": "ami-070a1367",
+    "aws_region": "us-west-1"
+}

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -59,6 +59,7 @@
       "ami_name": "ami-centos-7.4-{{user `kubernetes_version`}}-{{timestamp}}",
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
+      "region": "{{user `aws_region`}}",
       "ssh_username": "centos",
       "tags": {
         "build_version": "{{user `build_version`}}",


### PR DESCRIPTION
The original work for this was to address issue #120, and to also add information for source images in the AWS US-West-1 region.

Conformance tests now seem to have been pulled out into their own images, and with the proper yaml (supplied in the repo) -- they can easily be run from within any cluster. So conformance testing is more like "cluster conformance" than "node conformance". This just means that you need to stand up a single node cluster with the image that has been created and run the tests. The update to the README in the Packer folder details the updated steps.

Signed-off-by: Ryan Chapple <rchapple@vmware.com>