### PR TITLE
Fix Vagrantfile environment variables

### DIFF
--- a/swizzle/Vagrantfile
+++ b/swizzle/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  (1..WARDROOM_MASTER_COUNT).each do |i|
+  (1..WARDROOM_MASTER_COUNT.to_i).each do |i|
 
     config.vm.define "master#{i}" do |subconfig|
       subconfig.vm.hostname = "master#{i}.local"
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  (1..WARDROOM_NODE_COUNT).each do |i|
+  (1..WARDROOM_NODE_COUNT.to_i).each do |i|
     config.vm.define "node#{i}" do |subconfig|
       subconfig.vm.hostname = "node#{i}.local"
 


### PR DESCRIPTION
This Vagrantfile is interpretting environment variables as strings and
not ints. Adjust so that the environment variable is cast to an int
before iterating.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>