### PR TITLE
Make playbooks more composable

### DIFF
--- a/ansible/roles/kubernetes-master/tasks/install.yml
+++ b/ansible/roles/kubernetes-master/tasks/install.yml
@@ -45,9 +45,3 @@
 - name: initialize secondary masters
   command: "/usr/bin/kubeadm init --config=/etc/kubernetes/kubeadm.conf --ignore-preflight-errors=all"
   when: kubeadm_apiserver_manifest.stat.exists == False and inventory_hostname != groups['primary_master']|first
-
-- name: generate a kubeadm token
-  command: "/usr/bin/kubeadm token create --config /etc/kubernetes/kubeadm.conf --kubeconfig /etc/kubernetes/admin.conf"
-  register: generated_token
-  run_once: True
-  delegate_to: "{{ groups['primary_master']|first }}"

--- a/swizzle/add-nodes.yml
+++ b/swizzle/add-nodes.yml
@@ -1,0 +1,30 @@
+---
+- name: install ansible prerequisutess
+  import_playbook: ../ansible/pre.yml
+  tags:
+    - prereqs
+    - ansible-prereqs
+
+- name: create a kubeadm token
+  hosts: primary_master
+  tasks:
+    - name: generate a kubeadm token
+      command: "/usr/bin/kubeadm token create --config /etc/kubernetes/kubeadm.conf --kubeconfig /etc/kubernetes/admin.conf"
+      register: generated_token
+      run_once: True
+      delegate_to: "{{ groups['primary_master']|first }}"
+
+- name: install kubernetes prerequisites
+  hosts: nodes
+  become: yes
+  roles:
+    - role: common
+      when: common_enable|bool
+    - role: docker
+      when: docker_enable|bool
+    - role: kubernetes
+    - role: etcd
+      when: False
+    - role: kubernetes-node
+  tags:
+    - kubernetes-node

--- a/swizzle/ansible.cfg
+++ b/swizzle/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+display_skipped_hosts = false
 roles_path = ../ansible/roles
 hash_behaviour = merge
 

--- a/swizzle/install.yml
+++ b/swizzle/install.yml
@@ -27,7 +27,7 @@
       when: test_loadbalancer_enable|bool == True
 
 - name: install kubernetes prerequisites
-  hosts: nodes:masters
+  hosts: masters
   become: yes
   roles:
     - role: common
@@ -65,15 +65,7 @@
   tags:
     - kubernetes-cni
 
-- name: create kubernetes nodes
-  hosts: nodes
-  become: yes
-  roles:
-    - role: etcd
-      when: False
-    - role: kubernetes-node
-  tags:
-    - kubernetes-node
+- import_playbook: add-nodes.yml
 
 - name: setup kubernetes users
   hosts: masters

--- a/swizzle/main.yml
+++ b/swizzle/main.yml
@@ -1,0 +1,12 @@
+---
+- name: add node(s) to the cluster
+  import_playbook: add-nodes.yml
+  when: wardroom_action == 'add-nodes'
+
+- name: run cluster install
+  import_playbook: install.yml
+  when: wardroom_action == 'install'
+
+- name: run cluster upgrade
+  import_playbook: upgrade.yml
+  when: wardroom_action == 'upgrade'

--- a/swizzle/provision.py
+++ b/swizzle/provision.py
@@ -57,7 +57,7 @@ def vagrant_ssh_config(tempfile):
         fh.write(output)
 
 
-def run_ansible(playbook, inventory_file, extra_args=[]):
+def run_ansible(action, inventory_file, extra_args=[]):
     """ Run ansible playbook via subprocess.
     We do not want to link ansible as it is GPL """
 
@@ -71,10 +71,13 @@ def run_ansible(playbook, inventory_file, extra_args=[]):
     ansible_env['ANSIBLE_SSH_ARGS'] += " -F %s" % (ssh_tempfile[1])
     run_env.update(ansible_env)
 
+    playbook = "main.yml"
     cmd = [
         "ansible-playbook",
         "-i",
         inventory_file,
+        "-e",
+        "wardroom_action=%s" % action,
         playbook,
     ]
     cmd += extra_args
@@ -172,7 +175,7 @@ def state_purpose():
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-a', '--action', default='install',
-                        choices=['install', "upgrade"])
+                        choices=['install', "upgrade", 'add-nodes'])
     parser.add_argument('-o', '--os', default='xenial',
                         choices=WARDROOM_BOXES.keys())
     parser.add_argument('config')
@@ -195,8 +198,7 @@ def main():
     node_state = vagrant_status()
     inventory_file = generate_inventory(args.config, node_state)
 
-    playbook = "%s.yml" % args.action
-    run_ansible(playbook, inventory_file, extra_args)
+    run_ansible(args.action, inventory_file, extra_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Break out the playbooks such that users can selectively run parts of the
code. In particular, the act of adding nodes should be pretty
lightweight. Whereas currently we run the whole playbook to add nodes,
this introduces an add-nodes.yml playbook so that users do not need to
touch the control plane nodes.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>