### PR TITLE
Support kubelet environment file

### DIFF
--- a/ansible/roles/kubernetes-common/defaults/main.yml
+++ b/ansible/roles/kubernetes-common/defaults/main.yml
@@ -7,6 +7,7 @@ kubernetes_common_primary_interface: eth0
 
 # kubelet_extra_args is a dict of arg:value (ie. 'node-ip: 1.1.1.1' for '--node-ip=1.1.1.1')
 kubernetes_common_kubelet_extra_args: {}
+kubernetes_common_kubelet_env_vars: {}
 kubernetes_common_kubelet_config: {}
 
 kubernetes_common_kubeadm_config:

--- a/ansible/roles/kubernetes-common/tasks/main.yml
+++ b/ansible/roles/kubernetes-common/tasks/main.yml
@@ -32,11 +32,18 @@
 - name: drop extra args kubelet config
   template:
     backup: True
-    dest: /etc/systemd/system/kubelet.service.d/09-extra-args.conf
-    src: etc/systemd/system/kubelet.service.d/09-extra-args.conf
+    dest: "/etc/{{ 'default' if ansible_os_family == 'Debian' else 'sysconfig' }}/kubelet"
+    src: etc/default/kubelet
   notify:
     - restart kubelet
   when: kubernetes_common_primary_interface is defined or kubernetes_common_kubelet_extra_args is defined
+
+- name: delete old kubelet extra args unit file
+  file:
+    dest: /etc/systemd/system/kubelet.service.d/09-extra-args.conf
+    state: absent
+  notify:
+    - restart kubelet
 
 - name: open kubelet ports
   firewalld:

--- a/ansible/roles/kubernetes-common/tasks/main.yml
+++ b/ansible/roles/kubernetes-common/tasks/main.yml
@@ -36,7 +36,7 @@
     src: etc/default/kubelet
   notify:
     - restart kubelet
-  when: kubernetes_common_primary_interface is defined or kubernetes_common_kubelet_extra_args is defined
+  when: kubernetes_common_primary_interface is defined or kubernetes_common_kubelet_extra_args is defined or kubernetes_common_kubelet_env_vars is defined
 
 - name: delete old kubelet extra args unit file
   file:

--- a/ansible/roles/kubernetes-common/templates/etc/default/kubelet
+++ b/ansible/roles/kubernetes-common/templates/etc/default/kubelet
@@ -1,1 +1,5 @@
 KUBELET_EXTRA_ARGS={% if kubernetes_common_primary_interface is defined %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common_kubelet_extra_args.items() %} --{{k}}='{{v}}'{%- endfor %}
+
+{% for k, v in kubernetes_common_kubelet_env_vars.items() %}
+{{k}}='{{v}}'
+{% endfor %}

--- a/ansible/roles/kubernetes-common/templates/etc/default/kubelet
+++ b/ansible/roles/kubernetes-common/templates/etc/default/kubelet
@@ -1,0 +1,1 @@
+KUBELET_EXTRA_ARGS={% if kubernetes_common_primary_interface is defined %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common_kubelet_extra_args.items() %} --{{k}}='{{v}}'{%- endfor %}

--- a/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-extra-args.conf
+++ b/ansible/roles/kubernetes-common/templates/etc/systemd/system/kubelet.service.d/09-extra-args.conf
@@ -1,2 +1,0 @@
-[Service]
-Environment="KUBELET_EXTRA_ARGS={% if kubernetes_common_primary_interface is defined %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common_kubelet_extra_args.items() %} --{{k}}='{{v}}'{%- endfor %}"


### PR DESCRIPTION
With 1.11 the kubelet packages now support an external kubelet
environment file. Update the placement of this configuration from the
kubelet.d directory to the /etc/{default|sysconfig}/kubelet file.

Will cherry pick this change into the future branches as well.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>