### PR TITLE
Conditionalize the installation of docker-py

### DIFF
--- a/ansible/roles/docker/tasks/debian.yml
+++ b/ansible/roles/docker/tasks/debian.yml
@@ -27,7 +27,3 @@
   until: apt_result is success
   retries: 5
   delay: 5
-
-- name: install docker-py
-  pip:
-    name: docker-py

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -23,7 +23,3 @@
   file:
     dest: /etc/systemd/system/docker.service.d
     state: directory
-
-- name: install docker-py
-  pip:
-    name: docker-py

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -11,11 +11,17 @@
     state: started
     enabled: true
 
+# Required by the docker_image ansible module
+- name: install docker-py
+  pip:
+    name: docker-py
+  when: kubernetes_enable_cached_images|bool and kubernetes_cached_images|len > 0
+
 - name: cache docker images for kubeadm
   docker_image:
     name: "{{ item }}"
   with_items: kubernetes_cached_images
-  when: kubernetes_enable_cached_images | bool
+  when: kubernetes_enable_cached_images|bool and kubernetes_cached_images|len > 0
 
 - name: set kubernetes version file
   template:


### PR DESCRIPTION
Fixes #119 

The docker-py python module is required to use the ansible docker_image
module. The docker_image module is used only when caching images on the
nodes.

With this change, docker-py is only installed on the nodes when actually
needed.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>