### PR TITLE
Configure sysctl networking param in common role

### DIFF
--- a/ansible/roles/common/tasks/redhat.yml
+++ b/ansible/roles/common/tasks/redhat.yml
@@ -21,11 +21,3 @@
   modprobe:
     name: br_netfilter
     state: present
-
-- name: set sys.net.bridge.bridge-nf-call-iptables
-  sysctl:
-    name: net.bridge.bridge-nf-call-iptables
-    value: 1
-    sysctl_set: yes
-    state: present
-    reload: yes

--- a/ansible/roles/kubernetes-cni/tasks/flannel.yml
+++ b/ansible/roles/kubernetes-cni/tasks/flannel.yml
@@ -1,12 +1,4 @@
 ---
-- name: set ipv4 routing
-  sysctl:
-    name: net.bridge.bridge-nf-call-iptables
-    value: 1
-    sysctl_set: yes
-    state: present
-    reload: yes
-
 - name: install CNI networking
   command: "/usr/bin/kubectl apply -f {{ kubernetes_cni_flannel_manifest_url }}"
   run_once: True

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: set ipv4 routing
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes
+
 - import_tasks: debian.yml
   when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
Fixes #99 

We were setting a sysctl net parameter in multiple places. Given that this is
always required, move this task to the 'kubernetes' role, which is
common to both the wardroom and swizzle.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>