### PR TITLE
Cherry-pick into 1.12.x: Update the default docker version to address runc vuln. (#150)

### DIFF
--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 docker_enable: True
-docker_debian_version: '5:18.09.1~3-0~ubuntu-bionic'
-docker_redhat_version: '18.09.4-3.el7'
+docker_debian_version: '5:18.09.5~3-0~ubuntu-bionic'
+docker_redhat_version: '18.09.5-3.el7'
 docker_logging_max_size: 100m


### PR DESCRIPTION
Docker v18.09.2 addresses a runc vulnerability (CVE-2019-5736).
Update the default docker version to a version >= v18.09.2

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
