### PR TITLE
ubuntu 16.04 needs a specific version of urllib3

### DIFF
--- a/ansible/roles/common/tasks/debian.yml
+++ b/ansible/roles/common/tasks/debian.yml
@@ -18,3 +18,8 @@
   apt:
     name: "{{ common_extra_debs }}"
     state: latest
+
+- name: install specific version of urllib3
+  pip: 
+    name: urllib3==1.23
+  when: ansible_distribution_version == "16.04"


### PR DESCRIPTION

**What this PR does / why we need it**:
ubuntu 16.04 needs a specific urllib3 version to work with `modify_manifest.py`

**Which issue(s) this PR fixes**:


**Applies to Kubernetes versions**:

- tested on 1.13, would apply to all. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
without this change the task for modify_manifest.py fails with the following

Traceback (most recent call last):
  File "<stdin>", line 113, in <module>
  File "<stdin>", line 105, in _ansiballz_main
  File "<stdin>", line 48, in invoke_module
  File "/tmp/ansible_modify_manifest_payload_QYXdeQ/__main__.py", line 19, in <module>
  File "/usr/lib/python2.7/dist-packages/requests/__init__.py", line 58, in <module>
    from . import utils
  File "/usr/lib/python2.7/dist-packages/requests/utils.py", line 26, in <module>
    from .compat import parse_http_list as _parse_list_header
  File "/usr/lib/python2.7/dist-packages/requests/compat.py", line 42, in <module>
    from .packages.urllib3.packages.ordered_dict import OrderedDict
ImportError: No module named ordered_dict
```