### PR TITLE
Add virtualbox support to calico example

### DIFF
--- a/swizzle/examples/calico.yml
+++ b/swizzle/examples/calico.yml
@@ -8,6 +8,7 @@ all:
 {% elif vagrant_provider == 'virtualbox' %}
     kubernetes_common_primary_interface: eth1
     etcd_interface: eth1
+    test_loadbalancer_interface: eth1
 {% endif %}
     kubernetes_common_api_ip: "{{ loadbalancer_ip }}"
     kubernetes_common_api_fqdn: "k8s.example.com"


### PR DESCRIPTION
Signed-off-by: John Harris <joharris@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:
This PR adds the relevant NIC switch for virtualbox in the `examples/calico.yml` example.

**Which issue(s) this PR fixes**:
<!--
  optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close the issue(s) when PR gets merged)*
-->
Fixes #159 

**Applies to Kubernetes versions**:

- `1.` Master / all

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
