### PR TITLE
Become root when creating kubeadm token as part of add-nodes.yaml

### DIFF
--- a/swizzle/add-nodes.yml
+++ b/swizzle/add-nodes.yml
@@ -7,6 +7,7 @@
 
 - name: create a kubeadm token
   hosts: primary_master
+  become: yes
   tasks:
     - name: generate a kubeadm token
       command: "/usr/bin/kubeadm token create --config /etc/kubernetes/kubeadm.conf --kubeconfig /etc/kubernetes/admin.conf"


### PR DESCRIPTION
Kubeadm needs access to the kubeconfig file in
/etc/kubernetes/admin.conf. This file can only be used by a user with
elevated privileges.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>

Fixes #161 