### PR TITLE
Xenial non virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@
 Vagrant.configure("2") do |config|
 
   config.vm.define "xenial" do |conf|
-    conf.vm.box = "ubuntu/xenial64"
+    conf.vm.box = "generic/ubuntu1604"
     conf.vm.provider "virtualbox" do |v|
       v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
     end

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 docker_enable: True
-docker_debian_version: '5:18.09.5~3-0~ubuntu-bionic'
+docker_debian_version: '5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release | lower }}'
 docker_redhat_version: '18.09.5-3.el7'
 docker_logging_max_size: 100m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:
The ubuntu/xenial64 vagrant box only supports Virtualbox. Switch to generic/ubuntu1604
to support a wider range of Vagrant providers.

Additionally fixes up Docker installation on Xenial.

**Which issue(s) this PR fixes**:
None

**Applies to Kubernetes versions**:

- `1.12 onwards`

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
