### PR TITLE
Make the /etc/hosts management an opt-in feature

### DIFF
--- a/ansible/roles/kubernetes-common/defaults/main.yml
+++ b/ansible/roles/kubernetes-common/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kubernetes_common_disable_swap: True
-kubernetes_common_manage_etc_hosts: True
+kubernetes_common_manage_etc_hosts: False
 kubernetes_common_api_fqdn: k8s.example.com
 kubernetes_common_api_ip: 10.10.10.3
 kubernetes_common_primary_interface: eth0

--- a/swizzle/examples/calico.yml
+++ b/swizzle/examples/calico.yml
@@ -12,6 +12,7 @@ all:
 {% endif %}
     kubernetes_common_api_ip: "{{ loadbalancer_ip }}"
     kubernetes_common_api_fqdn: "k8s.example.com"
+    kubernetes_common_manage_etc_hosts: True
     kubernetes_cni_plugin: calico
     kubernetes_cni_calico_manifest_mods:
     - conditions:

--- a/swizzle/examples/canal.yml
+++ b/swizzle/examples/canal.yml
@@ -13,6 +13,7 @@ all:
 {% endif %}
     kubernetes_common_api_ip: "{{ loadbalancer_ip }}"
     kubernetes_common_api_fqdn: "k8s.example.com"
+    kubernetes_common_manage_etc_hosts: True
     kubernetes_cni_plugin: canal
     kubernetes_cni_canal_manifest_mods:
     - conditions:


### PR DESCRIPTION
Given that most environments should be able to leverage DNS to resolve
the common API server name, make the /etc/hosts management feature
opt-in.

Also update the existing provision.py example files to enable the
/etc/hosts management to avoid breaking them.

Fixes #165

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>
