### PR TITLE
[WIP] Leverage kubeadm to bootstrap a secure etcd cluster

### DIFF
--- a/ansible/roles/etcd/defaults/main.yml
+++ b/ansible/roles/etcd/defaults/main.yml
@@ -1,5 +1,25 @@
 ---
 etcd_enable: True
-etcd_cluster_token: 444fddcc-beae-45bc-9da6-d941d446b595
 etcd_interface: eth0
-etcd_version: v3.2.10
+# The etcd serving certificate must have the hostname and IP of all the etcd members.
+# This is because of a bug documented here: https://github.com/kubernetes/kubernetes/issues/72102
+etcd_server_cert_sans_hostnames: "{{ groups['etcd'] | list | sort }}"
+etcd_server_cert_sans_ips: "{{ groups['etcd'] | map('extract', hostvars, ['ansible_' + etcd_interface, 'ipv4', 'address']) | list | sort }}"
+etcd_server_cert_sans: "{{ etcd_server_cert_sans_hostnames + etcd_server_cert_sans_ips }}"
+etcd_kubeadm_config:
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: ClusterConfiguration
+  etcd:
+    local:
+      serverCertSANs: "{{ etcd_server_cert_sans }}"
+      peerCertSANs:
+      - "{{ inventory_hostname }}"
+      - "{{ hostvars[inventory_hostname]['ansible_' + etcd_interface]['ipv4']['address'] }}"
+      extraArgs:
+        initial-cluster: "{{ etcd_cluster_endpoints }}"
+        initial-cluster-state: new
+        name: "{{ inventory_hostname }}"
+        listen-peer-urls: "https://{{ hostvars[inventory_hostname]['ansible_' + etcd_interface]['ipv4']['address'] }}:2380"
+        listen-client-urls: "https://{{ hostvars[inventory_hostname]['ansible_' + etcd_interface]['ipv4']['address'] }}:2379"
+        advertise-client-urls: "https://{{ hostvars[inventory_hostname]['ansible_' + etcd_interface]['ipv4']['address'] }}:2379"
+        initial-advertise-peer-urls: "https://{{ hostvars[inventory_hostname]['ansible_' + etcd_interface]['ipv4']['address'] }}:2380"

--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -1,57 +1,67 @@
 ---
-- name: download and extract etcd binaries
-  unarchive:
-    remote_src: True
-    src: "{{ etcd_release_url }}"
-    dest: /tmp
-    creates: /usr/local/bin/etcd
-  register: etcd_downloaded
-
-- name: move binaries into path
-  copy:
-    remote_src: True
-    src: "/tmp/etcd-{{ etcd_version }}-linux-amd64/{{ item }}"
-    dest: "/usr/local/bin/{{ item }}"
-  with_items:
-    - etcd
-    - etcdctl
-  when: etcd_downloaded is changed
-
-- name: set permissions on etcd binaries
-  file:
-    dest: "/usr/local/bin/{{ item }}"
-    mode: 0755
-    state: file
-  with_items:
-    - etcd
-    - etcdctl
-
-- name: create data directory
-  file:
-    dest: /var/lib/etcd
-    state: directory
-
-- name: open etcd ports
-  firewalld:
-    port: "{{ item }}"
-    permanent: yes
-    state: enabled
-    immediate: True
-  with_items:
-  - "2379/tcp"
-  - "2380/tcp"
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
-- name: etcd systemd template
+- name: configure kubelet
   template:
-    src: etc/systemd/system/etcd.service
-    dest: /etc/systemd/system/etcd.service
-  tags:
-    - etcd2
+    src: etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
+    dest: /etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
 
-- name: enable and start the service
+- name: enable kubelet service
   systemd:
-    name: etcd
-    daemon_reload: True
-    state: started
+    name: kubelet
+    state: restarted # TODO: Only restart the kubelet if the above configuration changed
     enabled: True
+    daemon_reload: True
+
+- name: generate etcd ca certificate
+  command: /usr/bin/kubeadm init phase certs etcd-ca
+  run_once: True
+  delegate_to: "{{ groups['etcd']|first }}"
+  
+- name: slurp the etcd ca certificate and key
+  slurp:
+    src: "/etc/kubernetes/pki/etcd/{{ item }}"
+  run_once: True
+  delegate_to: "{{ groups['etcd']|first }}"
+  register: etcd_ca_pki
+  with_items:
+  - ca.crt
+  - ca.key
+
+- name: ensure etcd pki directory exists
+  file:
+    dest: /etc/kubernetes/pki/etcd
+    state: directory
+    owner: root
+    group: root
+
+- name: distribute etcd ca certificate and key
+  no_log: True
+  copy:
+    dest: "{{ item.source }}"
+    content: "{{ item.content | b64decode }}"
+    owner: root
+    group: root
+    mode: 0700
+  with_items: "{{ etcd_ca_pki.results }}"
+  when: inventory_hostname != groups['etcd']|first
+  
+- name: drop kubeadm configuration file
+  template:
+    src: etc/kubernetes/kubeadm-etcd.yaml
+    dest: /etc/kubernetes/kubeadm-etcd.yaml
+
+- name: generate etcd certificates
+  command: "/usr/bin/kubeadm init phase certs {{ item }} --config /etc/kubernetes/kubeadm-etcd.yaml"
+  with_items:
+  - etcd-server
+  - etcd-peer
+  - etcd-healthcheck-client
+  - apiserver-etcd-client
+
+- name: generate etcd static pod manifest
+  command: "/usr/bin/kubeadm init phase etcd local --config /etc/kubernetes/kubeadm-etcd.yaml"
+
+# This is a hack to support stacked and external etcd.
+- name: delete kubelet systemd drop-in if stacked
+  file:
+    path: /etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
+    state: absent

--- a/ansible/roles/etcd/templates/etc/kubernetes/kubeadm-etcd.yaml
+++ b/ansible/roles/etcd/templates/etc/kubernetes/kubeadm-etcd.yaml
@@ -1,0 +1,2 @@
+---
+{{ etcd_kubeadm_config | to_nice_yaml(indent=2) }}

--- a/ansible/roles/etcd/templates/etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
+++ b/ansible/roles/etcd/templates/etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
@@ -1,0 +1,4 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true
+Restart=always

--- a/ansible/roles/etcd/vars/main.yml
+++ b/ansible/roles/etcd/vars/main.yml
@@ -1,4 +1,3 @@
 ---
-etcd_release_url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
-etcd_client_endpoints: "{{ groups['etcd']|map('extract', hostvars, ['ansible_' + etcd_interface, 'ipv4', 'address'])|map('regex_replace', '^(.*)$', 'http://\\1:2379')|list|sort }}"
-etcd_cluster_endpoints: "{% for host in groups['etcd']|sort %}{{hostvars[host]['inventory_hostname']}}=http://{{hostvars[host]['ansible_' + etcd_interface]['ipv4']['address']}}:2380{% if not loop.last %},{% endif %}{% endfor %}"
+etcd_client_endpoints: "{{ groups['etcd']|map('extract', hostvars, ['ansible_' + etcd_interface, 'ipv4', 'address'])|map('regex_replace', '^(.*)$', 'https://\\1:2379')|list|sort }}"
+etcd_cluster_endpoints: "{% for host in groups['etcd']|sort %}{{hostvars[host]['inventory_hostname']}}=https://{{hostvars[host]['ansible_' + etcd_interface]['ipv4']['address']}}:2380{% if not loop.last %},{% endif %}{% endfor %}"

--- a/ansible/roles/kubernetes-common/defaults/main.yml
+++ b/ansible/roles/kubernetes-common/defaults/main.yml
@@ -20,3 +20,6 @@ kubernetes_common_kubeadm_config:
   etcd:
     external:
       endpoints: "{{ etcd_client_endpoints }}"
+      caFile: /etc/kubernetes/pki/etcd/ca.crt
+      certFile: /etc/kubernetes/pki/apiserver-etcd-client.crt
+      keyFile: /etc/kubernetes/pki/apiserver-etcd-client.key

--- a/ansible/roles/kubernetes-master/tasks/main.yml
+++ b/ansible/roles/kubernetes-master/tasks/main.yml
@@ -19,6 +19,30 @@
     immediate: True
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
 
+- name: ensure etcd pki directory exists
+  file:
+    dest: /etc/kubernetes/pki/etcd
+    state: directory
+
+- name: slurp the client cert and key for etcd communication
+  slurp:
+    src: "/etc/kubernetes/pki/{{ item }}"
+  with_items:
+    - apiserver-etcd-client.crt
+    - apiserver-etcd-client.key
+    - etcd/ca.crt
+  register: etcd_certs
+  delegate_to: "{{ groups['etcd']|first }}"
+  run_once: True
+
+- name: distribute the certificates
+  copy:
+    dest: "{{ item.source }}"
+    content: "{{ item.content | b64decode }}"
+    mode: 0700 # TODO: check these permissions
+  with_items: "{{ etcd_certs.results }}"
+  no_log: True
+  
 - include_tasks: install.yml
   when: wardroom_action == 'install'
 

--- a/swizzle/install.yml
+++ b/swizzle/install.yml
@@ -34,7 +34,7 @@
       when: common_enable|bool
     - role: docker
       when: docker_enable|bool
-    - kubernetes
+    - role: kubernetes
   tags:
     - prereqs
     - kubernetes-prereqs
@@ -45,8 +45,10 @@
   roles:
     - role: common
       when: common_enable|bool
+    - role: docker
+      when: docker_enable|bool
+    - role: kubernetes
     - role: etcd
-    
   tags:
     - etcd
 


### PR DESCRIPTION
Creating this draft PR to get some eyes on this.

In the current state, we are creating a systemd drop-in to get the kubelet into a working state so that it starts up the etcd static pods. The problem is that this drop-in overrides the kubeadm drop-in, which results in kubeadm being unable to properly configure the kubelet at `kubeadm init` time.

