### PR TITLE
Introduce additional documentation and revamp README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,50 @@
-wardroom
-========
+# wardroom
 
-A tool for creating Kubernetes-ready base operating system images. wardroom leverages [Packer](https://github.com/hashicorp/packer) to build golden images of Kubernetes deployments across a wide variety of operating systems as well as image formats. This repo is the basis for the images used in Heptio's [aws-quickstart](https://github.com/heptio/aws-quickstart).
+Wardroom provides tooling that helps simplify the deployment of a Kubernetes cluster. More
+specifically, Wardroom provides the following functionality:
 
-supported operating systems
----------------------------
+* **Image Building**: Building of Kubernetes-ready base operating system images using Packer and Ansible.
+* **Deployment Orchestration**: Ansible-based orchestration to deploy highly-available Kubernetes
+  clusters using kubeadm.
 
-- Ubuntu 16.04 (Xenial)
-- Ubuntu 18.04 (Bionic)
-- CentOS 7
+Both use cases share a common set of [Ansible](https://github.com/ansible/ansible) roles that can
+be found in the [ansible](./ansible) directory.
 
-currently supported image formats (more to follow)
---------------------------------------------------
+## Image Building
 
-- AMI
+Wardroom leverages [Packer](https://github.com/hashicorp/packer) to build golden images of
+Kubernetes deployments across a wide variety of operating systems as well as image formats. During
+the build phase, Wardroom leverages [Ansible](https://github.com/ansible/ansible) to configure the
+base operating system and produce the Kubernetes-ready golden image.
 
-image building
---------------
+This functionality is used to create base images for the Heptio
+[aws-quickstart](https://github.com/heptio/aws-quickstart).
 
-All images are built with Packer, and configuration and details may be found in the [packer](./packer) directory.
+### Supported Image Formats
 
-contributing
-------------
+* AMI
 
-See our [contributing](CONTRIBUTING.md) guidelines and our [code of conduct](CODE-OF-CONDUCT.md). Contributions welcome by all.
+### Supported Operating Systems
 
-swizzle
--------
+* Ubuntu 16.04 (Xenial)
+* Ubuntu 18.04 (Bionic)
+* CentOS 7
 
-The [swizzle](./swizzle) directory is a sample implementation of how one might further leverage the [ansible](https://www.ansible.com/) playbooks therein to deploy Kubernetes. As this is a proof of concept, please be aware that this code is subject to change. There is a desire to remove this code once further rigor around kubeadm HA strategies are in place.
+## Deployment Orchestration
 
-development
------------
+The [swizzle](./swizzle) directory contains an Ansible playbook that can be used to orchestrate the
+deployment of a Kubernetes cluster using kubeadm.
+
+## Documentation
+
+Documentation and usage information can be found in the [docs](./docs) directory.
+
+## Contributing
+
+See our [contributing](CONTRIBUTING.md) guidelines and our [code of conduct](CODE-OF-CONDUCT.md).
+Contributions welcome by all.
+
+## Development
 
 [Vagrant](https://www.vagrantup.com/) may be used to test local ansible playbook development. In this scenario, Vagrant makes use of the ansible provisioner to configure the resulting operating system image. To test all operating systems simultaneously:
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,4 +1,5 @@
 ---
+# This playbook is used by the packer build to create Kubernetes-ready OS images.
 - import_playbook: pre.yml
 
 - name: build image

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 This directory contains documentation for the Wardroom project.
 
 * _[Architecture](architecture.md):_ Describes the current architecture of the Wardroom project.
+* _[Building Kubernetes-ready Base OS Images](building-images.md)_: Describes how to use Wardroom to build Kubernetes-ready base OS images.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ This directory contains documentation for the Wardroom project.
 
 * _[Architecture](architecture.md):_ Describes the current architecture of the Wardroom project.
 * _[Building Kubernetes-ready Base OS Images](building-images.md)_: Describes how to use Wardroom to build Kubernetes-ready base OS images.
+* _[Bootstrapping a Kubernetes Cluster](bootstrapping-a-kubernetes-cluster.md)_: Describes how to use Wardroom to bootstrap a Kubernetes cluster.

--- a/docs/bootstrapping-a-kubernetes-cluster.md
+++ b/docs/bootstrapping-a-kubernetes-cluster.md
@@ -101,10 +101,11 @@ kubernetes_common_kubeadm_config:
 #### Modifying CNI Manifests
 
 Wardroom provides a mechanism to modify the YAML deployment manfiests of the CNI plugin before
-installing it in the cluster.
+installing it in the cluster. This mechanism is implemented as an ansible library, which allows
+you to express conditions as well as modifications using jsonpath syntax.
 
 The following example shows how to set the `CALICO_IPV4POOL_CIDR` environment variable in the
-Calico deployment manifests. This must be defined in the `extra_vars.yml` file:
+Calico deployment manifests. This must be defined in your inventory or an `extra_vars.yml` file:
 
 ```yaml
 kubernetes_cni_calico_manifest_mods:
@@ -129,7 +130,7 @@ ansible-playbook install.yml --inventory inventory.ini --extra-vars @extra_vars.
 Within the `swizzle` directory, Wardroom provides a Vagrantfile and the `provision.py` script for
 development and testing purposes.
 
-The `provision.py` script generates ansible extra variables from templates in the `examples/` directory.
+The `provision.py` script generates ansible inventories from templates in the `examples/` directory.
 
 To create a cluster using `provision.py`:
 

--- a/docs/bootstrapping-a-kubernetes-cluster.md
+++ b/docs/bootstrapping-a-kubernetes-cluster.md
@@ -1,0 +1,144 @@
+# Bootstrapping a Kubernetes Cluster
+
+Wardroom leverages Ansible to provide orchestration around the process of bootstrapping a
+Kubernetes cluster with kubeadm. The Ansible playbooks and files related to this functionality can
+be found in the [swizzle](../swizzle) directory.
+
+It is important to note that Wardroom does not provide infrastructure provisioning automation.
+Thus, all the infrastructure must be readily available before attempting to use Wardroom to
+bootstrap a Kubernetes cluster.
+
+## Prerequisites
+
+- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.4.0.0
+- Nodes up and running (they are not required to be running a Wardroom-built base OS image)
+- SSH Credentials
+
+## Bootstrapping a Cluster
+
+The following steps assume your current working directory is the `swizzle/` directory.
+
+### Create Inventory
+
+Create an Ansible
+[inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html) file that
+lists all the nodes of the cluster. The following host groups are supported:
+
+- `etcd`: List of hosts that will run etcd.
+- `masters`: List of Kubernetes control planes nodes.
+- `primary_master`: The first control plane node. There is nothing special about this node, other
+  than being the node where `kubeadm init` is run. This node must also be part of the `masters`
+  group.
+- `nodes`: List of Kubernetes worker nodes.
+
+_Note: Using Ansible's dynamic inventory feature should be possible, but it is outside of the scope of
+this document._ 
+
+#### Stacked Masters or External Etcd Cluster
+
+Wardroom supports two etcd deployment patterns:
+
+- _Stacked Masters_: Etcd runs on the same nodes as the Kubernetes Control Plane. To deploy stacked
+  masters, the `etcd` host group must equal the `masters` host group.
+- _External Etcd Cluster_: Etcd runs on a dedicated set of nodes. To deploy an external etcd
+  cluster, the `etcd` host group must have no overlap with the `masters` host group.
+
+### Configure the Installation
+
+The Ansible roles expose a set of variables that can be used to customize the installation to your
+specific environment. Most variables have defaults defined in the `defaults/` directory of each
+role.
+
+To configure the installation, create an `extra_vars.yml` file to capture the variables for your
+environment. The following is a sample that includes commonly used variables:
+
+```yaml
+etcd_interface: eth0 # Interface that etcd should bind
+kubernetes_common_primary_interface: eth0 # Interface that should be used to obtain the node's IP
+kubernetes_cni_plugin: calico # The CNI plugin to use
+```
+
+_Note: Wardroom sets Ansible's [hash merging behavior](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-hash-behaviour)
+to `merge`. This means that any variable that is a hash (aka. map or dictionary) with a default
+value will be merged with the user-provided variable._
+
+#### Kubernetes API IP or FQDN
+
+When setting up a highly-available Kubernetes cluster, the control plane must be accessible through
+a single address. This is typically achieved by deploying a load balancer in front of the control
+plane nodes.
+
+Wardroom exposes two variables to provide the load-balanced API address:
+
+```yaml
+# IP address of the load balancer fronting the Kubernetes API servers.
+# This is required if an FQDN is not provided. Otherwise, this can be left empty.
+kubernetes_common_api_ip: ""
+
+# FQDN of the load balancer fronting the Kubernetes API servers.
+# This variable takes precedence over the kubernetes_common_api_ip variable.
+kubernetes_common_api_fqdn: ""
+```
+
+#### Modifying Kubeadm Configuration
+
+The kubeadm configuration is provided via the `kubernetes_common_kubeadm_config` variable. Wardroom
+provides a [default](../ansible/roles/kubernetes-common/defaults/main.yml) for this variable that
+can be modified through the `extra_vars.yml` file.
+
+Given that the variable is a hash (or map), the user-provided variable is merged with the default
+variable. This provides the ability to make point modifications without having to redefine the
+entire variable.
+
+The following example shows how to set the pod CIDR in the `extra_vars.yml` file:
+
+```yaml
+kubernetes_common_kubeadm_config:
+  networking:
+    podSubnet: "172.16.0.0/16"
+```
+
+#### Modifying CNI Manifests
+
+Wardroom provides a mechanism to modify the YAML deployment manfiests of the CNI plugin before
+installing it in the cluster.
+
+The following example shows how to set the `CALICO_IPV4POOL_CIDR` environment variable in the
+Calico deployment manifests. This must be defined in the `extra_vars.yml` file:
+
+```yaml
+kubernetes_cni_calico_manifest_mods:
+  - conditions:
+    - expression: kind
+      value: DaemonSet
+    modifications:
+    - expression: "spec.template.spec.containers[?(@.name == 'calico-node')].env[?(@.name == 'CALICO_IPV4POOL_CIDR')].value"
+      value: "172.16.0.0/16"
+```
+
+### Run Ansible
+
+Once you have the inventory and extra variables files, run the playbook:
+
+```shell
+ansible-playbook install.yml --inventory inventory.ini --extra-vars @extra_vars.yml
+```
+
+## Vagrant and provision.py
+
+Within the `swizzle` directory, Wardroom provides a Vagrantfile and the `provision.py` script for
+development and testing purposes.
+
+The `provision.py` script generates ansible extra variables from templates in the `examples/` directory.
+
+To create a cluster using `provision.py`:
+
+```shell
+python provision.py -a install -o xenial examples/calico.yml
+```
+
+To destroy the cluster:
+
+```shell
+vagrant destroy -f
+```

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -1,4 +1,4 @@
-# Building Wardroom Images
+# Building Kubernetes-ready Base Operating System Images
 
 This directory contains tooling for building base images for use as nodes in Kubernetes Clusters. [Packer](https://www.packer.io) is used for building these images.
 
@@ -9,7 +9,7 @@ This directory contains tooling for building base images for use as nodes in Kub
         - [Prerequisites for Google Cloud](#prerequisites-for-google-cloud)
     - [Building Images](#building-images)
         - [Build Variables](#build-variables)
-        - [Limiting Images to Build](#limiting-images-to-build)
+        - [Building Specific Images](#building-specific-images)
         - [Building the AWS AMIs](#building-the-aws-amis)
         - [Building Google Cloud Images](#building-google-cloud-images)
     - [Testing Images](#testing-images)
@@ -58,7 +58,7 @@ packer build -var kubernetes_version=1.8.9-00 -var build_version=1
 
 There are additional variables that may be set that affect the behavior of specific builds or packer post-processors. `packer inspect packer.json` will list all available variables and their default values.
 
-### Limiting Images to Build
+### Building Specific Images
 
 If packer build is run without specifying which images to build, then it will attempt to build all configured images. `packer inspect packer.json` will list the configured builders. The `--only` option can be specified when running `packer build` to limit the images built.
 
@@ -70,7 +70,7 @@ packer build -var build_version=`git rev-parse HEAD` --only=ami-ubuntu packer.js
 
 ### Building the AWS AMIs
 
-Building AWS images requires setting additional variables not set by default. The `aws-us-east-1.json` file is provided as an example.
+Building AWS images requires setting additional variables not set by default. The `packer/aws-us-east-1.json` file is provided as an example.
 
 To build both the Ubuntu and CentOS AWS AMIs:
 
@@ -112,7 +112,7 @@ The [Packer documentation for the Amazon AMI builder](https://www.packer.io/docs
 
 ### Building Google Cloud Images
 
-Building Google Cloud images requires setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable and providing the IDs of the source images. For the latter, the `gcp-source-images.json` file is provided as an example.
+Building Google Cloud images requires setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable and providing the IDs of the source images. For the latter, the `packer/gcp-source-images.json` file is provided as an example.
 
 To build only the Ubuntu Google Cloud Image:
 
@@ -158,7 +158,12 @@ You will also need the following pieces of information:
 To build an OCI image:
 
 ```sh
-packer build -var-file oci-us-phoenix-1.json -var build_version=`git rev-parse HEAD` -var oci_availability_domain="<name of availability domain>" -var oci_compartment_ocid="<OCID of compartment>" -var oci_subnet_ocid="<OCID of subnet in specified availability domain>" -only=oci-ubuntu packer.json
+packer build -var-file oci-us-phoenix-1.json \
+    -var build_version=`git rev-parse HEAD` \
+    -var oci_availability_domain="<name of availability domain>" \
+    -var oci_compartment_ocid="<OCID of compartment>" \
+    -var oci_subnet_ocid="<OCID of subnet in specified availability domain>" \
+    -only=oci-ubuntu packer.json
 ```
 
 ## Testing Images

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,5 @@
+packer
+=======
+The packer directory includes the packer configuration to build Kubernetes-ready operating system images.
+
+For usage information, see the user documentation [here](../docs/building-images.md).

--- a/swizzle/README.md
+++ b/swizzle/README.md
@@ -1,40 +1,5 @@
 swizzle
 =======
-The swizzle directory includes a playbook used to orchestrate the installation of Kubernetes by way of kubeadm. This add the ability to make kubeadm HA.
+The swizzle directory includes an Ansible playbook used to orchestrate the installation of Kubernetes by way of kubeadm.
 
-Usage
------
-Vagrant:
-```
-$ python provision.py
-```
-
-Ansible:
-
-Assumes you have machines up and ready to use for your cluster.  They need to be either Debian or Red Hat derivatives.  Nothing need be installed besides the base OS.
-
-1. Create an inventory file and edit it to reflect your infrastructure.
-
-    ```
-    $ cp inventory.ini.example inventory.ini
-    ```
-
-2. Create an extra vars file and edit to contain the values that will work for your cluster and infrastructure.  The values contained in the example are the default values so you can delete those you don't wish to change or that don't apply to your installation.
-
-    ```
-    $ cp extra_vars.yaml.example extra_vars.yaml
-    ```
-
-3. Tell ansible where to find the roles.
-
-    ```
-    $ export ANSIBLE_ROLES_PATH=../ansible/roles
-    ```
-
-4. Run the playbook.
-
-    ```
-    $ ansible-playbook -i inventory.ini swizzle.yml --extra-vars "@extra_vars.yaml"
-    ```
-
-This playbook make use of the baseline config management provided by the various wardoom roles. We do not use the native Vagrant ansible support (ie. `vagrant provision`) as it does not execute playbooks across all virtual machines simultaneously; only serially.
+For usage information, see the user documentation [here](../docs/bootstrapping-a-kubernetes-cluster.md)

--- a/swizzle/examples/calico.yml
+++ b/swizzle/examples/calico.yml
@@ -1,4 +1,6 @@
 ---
+# This is an example of an extra_vars file that can be used with provision.py
+# It contains jinja variables that are substitued by provision.py
 all:
   vars:
     docker_debian_version: "18.03.1~ce~3-0~ubuntu"

--- a/swizzle/examples/calico.yml
+++ b/swizzle/examples/calico.yml
@@ -1,5 +1,5 @@
 ---
-# This is an example of an extra_vars file that can be used with provision.py
+# This is an example of an inventory file that can be used with provision.py
 # It contains jinja variables that are substitued by provision.py
 all:
   vars:

--- a/swizzle/examples/canal.yml
+++ b/swizzle/examples/canal.yml
@@ -1,4 +1,6 @@
 ---
+# This is an example of an extra_vars file that can be used with provision.py
+# It contains jinja variables that are substitued by provision.py
 all:
   vars:
     docker_debian_version: "18.03.1~ce~3-0~ubuntu"

--- a/swizzle/examples/canal.yml
+++ b/swizzle/examples/canal.yml
@@ -1,5 +1,5 @@
 ---
-# This is an example of an extra_vars file that can be used with provision.py
+# This is an example of an inventory file that can be used with provision.py
 # It contains jinja variables that are substitued by provision.py
 all:
   vars:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:
This PR introduces additional documentation on how to use the swizzle functionality of wardroom.

In addition, it attempts to clarify the README with the goal of communicating that wardroom solves two things.

**Which issue(s) this PR fixes**:
<!--
  optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close the issue(s) when PR gets merged)*
-->
Fixes #130 

**Special notes for your reviewer**:

Given that we created a `docs/` directory, I have put all the user-facing documentation there. For example, you will notice that the README that used to live in the `packer/` directory has migrated to the `docs/` dir.

With that in mind, I am not entirely sure if it makes sense to have README files in the `packer` and `swizzle` directory. One idea that crossed my mind is that we could put developer-facing documentation in those READMEs. At the moment, they describe the purpose of the directory and point the reader to the user-facing documentation.

When it comes to ansible variables, I thought about documenting all the available variables. However, I think the list or table will quickly get out of sync as we evolve wardroom. Instead, I opted for documenting some of the variables that are commonly set.

cc @rchapple 