### PR TITLE
Add missing --network-plugin parameter

### DIFF
--- a/ansible/roles/kubernetes-common/templates/etc/default/kubelet
+++ b/ansible/roles/kubernetes-common/templates/etc/default/kubelet
@@ -1,4 +1,4 @@
-KUBELET_EXTRA_ARGS={% if kubernetes_common_primary_interface is defined %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common_kubelet_extra_args.items() %} --{{k}}='{{v}}'{%- endfor %}
+KUBELET_EXTRA_ARGS=--network-plugin=cni {% if kubernetes_common_primary_interface is defined %} --node-ip={{kubernetes_node_ip}}{% endif %}{% for k, v in kubernetes_common_kubelet_extra_args.items() %} --{{k}}='{{v}}'{%- endfor %}
 
 {% for k, v in kubernetes_common_kubelet_env_vars.items() %}
 {{k}}='{{v}}'


### PR DESCRIPTION
It is unclear why the kubelet no longer set this parameter by default,
but it is necessary for installs and upgrades. Adding it to the
/etc/kubelet/default file.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>

