### PR TITLE
Vagrant: Add optimizations, refactor commonalities into Ruby library

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+# Copyright 2019 The Wardroom Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 140
+
+Style/ClassVars:
+  Enabled: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,34 +1,37 @@
+# Copyright 2019 The Wardroom Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
+require_relative 'lib/vagrant-wardroom/providers.rb'
 
-Vagrant.configure("2") do |config|
-
-  config.vm.define "xenial" do |conf|
-    conf.vm.box = "generic/ubuntu1604"
-    conf.vm.provider "virtualbox" do |v|
-      v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
-    end
+Vagrant.configure('2') do |config|
+  config.vm.define 'xenial' do |conf|
+    conf.vm.box = 'generic/ubuntu1604'
+    VagrantWardroom::Providers.configure(conf)
   end
 
-  config.vm.define "bionic" do |conf|
-    conf.vm.box = "generic/ubuntu1804"
-    conf.vm.provider "virtualbox" do |v|
-      v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
-    end
+  config.vm.define 'bionic' do |conf|
+    conf.vm.box = 'generic/ubuntu1804'
+    VagrantWardroom::Providers.configure(conf)
   end
 
-  config.vm.define "centos7" do |conf|
-    conf.vm.box = "centos/7"
+  config.vm.define 'centos7' do |conf|
+    conf.vm.box = 'centos/7'
+    VagrantWardroom::Providers.configure(conf)
   end
 
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "ansible/playbook.yml"
+  config.vm.provision 'ansible' do |ansible|
+    ansible.playbook = 'ansible/playbook.yml'
     ansible.verbose = ENV['WARDROOM_VERBOSE'] || false
   end
-
 end

--- a/lib/vagrant-wardroom/providers.rb
+++ b/lib/vagrant-wardroom/providers.rb
@@ -1,0 +1,26 @@
+# Copyright 2019 The Wardroom Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'providers/libvirt.rb'
+require_relative 'providers/virtualbox.rb'
+
+# Helper module for Wardroom
+module VagrantWardroom
+  # Helper modules for different Vagrant providers
+  module Providers
+    module_function
+
+    def configure(conf, **params)
+      VirtualBox.configure(conf, params)
+      Libvirt.configure(conf, params)
+    end
+  end
+end

--- a/lib/vagrant-wardroom/providers/libvirt.rb
+++ b/lib/vagrant-wardroom/providers/libvirt.rb
@@ -1,0 +1,28 @@
+# Copyright 2019 The Wardroom Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper module for Wardroom
+module VagrantWardroom
+  # Helper modules for different Vagrant providers
+  module Providers
+    # Helper functions to configure Libvirt
+    module Libvirt
+      module_function
+
+      def configure(conf, _params)
+        conf.vm.provider 'libvirt' do |libvirt|
+          libvirt.cpu_mode = 'host-passthrough'
+          libvirt.disk_bus = 'virtio'
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-wardroom/providers/virtualbox.rb
+++ b/lib/vagrant-wardroom/providers/virtualbox.rb
@@ -1,0 +1,59 @@
+# Copyright 2019 The Wardroom Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper module for Wardroom
+module VagrantWardroom
+  # Helper modules for different Vagrant providers
+  module Providers
+    # Helper functions to configure VirtualBox
+    module VirtualBox
+      module_function
+
+      FIRST_PARAVIRTUALIZATION_VERSION = Gem::Version.new('5.0.2')
+      WARDROOM_NETWORK_NAME = ENV['WARDROOM_NETWORK_NAME'] || 'wardroom-private'
+
+      def driver
+        @@driver ||= VagrantPlugins::ProviderVirtualBox::Driver::Meta.new
+      end
+
+      def virtualbox_version
+        @@virtualbox_version ||= Gem::Version.new(driver.version)
+      end
+
+      def supports_paravirtualization?
+        @@supports_paravirtualization ||= Gem::Version.new(driver.version) >= FIRST_PARAVIRTUALIZATION_VERSION
+      end
+
+      def enable_high_performance(vbox)
+        vbox.customize ['modifyvm', :id, '--paravirtprovider', 'kvm'] if supports_paravirtualization?
+        vbox.customize ['modifyvm', :id, '--largepages', 'on']
+        vbox.customize ['modifyvm', :id, '--vtxvpid', 'on']
+        vbox.customize ['modifyvm', :id, '--x2apic', 'on']
+        vbox.customize ['modifyvm', :id, '--biosapic', 'x2apic']
+        vbox.customize ['modifyvm', :id, '--hpet', 'on']
+      end
+
+      def disable_uart(vbox)
+        vbox.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
+      end
+
+      def configure(conf, params)
+        conf.vm.provider 'virtualbox' do |vbox, override|
+          disable_uart(vbox)
+          enable_high_performance(vbox)
+          override.vm.network 'private_network', ip: params[:ip], virtualbox__intnet: WARDROOM_NETWORK_NAME if params.key?(:ip)
+          vbox.memory = params[:memory] if params.key?(:memory)
+          vbox.linked_clone = true if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+        end
+      end
+    end
+  end
+end

--- a/swizzle/Vagrantfile
+++ b/swizzle/Vagrantfile
@@ -1,62 +1,51 @@
+# Copyright 2019 The Wardroom Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
-WARDROOM_MASTER_COUNT = ENV["WARDROOM_MASTER_COUNT"] || 3
-WARDROOM_NODE_COUNT = ENV["WARDROOM_NODE_COUNT"] || 1
-WARDROOM_BOX = ENV["WARDROOM_BOX"] || "generic/ubuntu1804"
-WARDROOM_NETWORK_NAME = ENV["WARDROOM_NETWORK_NAME"] || "wardroom-private"
+require_relative '../lib/vagrant-wardroom/providers.rb'
 
-$update_dns = <<-SCRIPT
+WARDROOM_MASTER_COUNT = ENV['WARDROOM_MASTER_COUNT'] || 3
+WARDROOM_NODE_COUNT = ENV['WARDROOM_NODE_COUNT'] || 1
+WARDROOM_BOX = ENV['WARDROOM_BOX'] || 'generic/ubuntu1804'
+
+UPDATE_DNS_SCRIPT = <<-SCRIPT.freeze
   if grep -qi debian /etc/os-release; then
     sudo sed -i "s/\\[4.2.2.*/\\[8.8.8.8, 8.8.4.4\\]/g" /etc/netplan/01-netcfg.yaml;
     sudo netplan apply;
   fi;
 SCRIPT
 
-Vagrant.configure("2") do |config|
-
+Vagrant.configure('2') do |config|
   config.vm.box = WARDROOM_BOX
 
-  config.vm.provider :libvirt do |libvirt|
-    libvirt.disk_bus = "virtio"
-  end
+  config.vm.provision 'shell', inline: UPDATE_DNS_SCRIPT
 
-  config.vm.provision "shell", inline: $update_dns
-
-  config.vm.define "loadbalancer" do |subconfig|
-    subconfig.vm.hostname = "loadbalancer"
-
-    subconfig.vm.provider "virtualbox" do |v, override|
-      override.vm.network "private_network", :ip => "10.10.10.3", virtualbox__intnet: WARDROOM_NETWORK_NAME
-    end
+  config.vm.define 'loadbalancer' do |subconfig|
+    subconfig.vm.hostname = 'loadbalancer'
+    VagrantWardroom::Providers.configure(subconfig, ip: '10.10.10.3')
   end
 
   (1..WARDROOM_MASTER_COUNT.to_i).each do |i|
-
     config.vm.define "master#{i}" do |subconfig|
       subconfig.vm.hostname = "master#{i}.local"
-
-      subconfig.vm.provider "virtualbox" do |v, override|
-        override.vm.network "private_network", :ip => "10.10.10.1#{i}", virtualbox__intnet: WARDROOM_NETWORK_NAME
-  	v.memory = 1024
-        v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
-      end
+      VagrantWardroom::Providers.configure(subconfig, ip: "10.10.10.1#{i}", memory: 1024)
     end
   end
 
   (1..WARDROOM_NODE_COUNT.to_i).each do |i|
     config.vm.define "node#{i}" do |subconfig|
       subconfig.vm.hostname = "node#{i}.local"
-
-      subconfig.vm.provider "virtualbox" do |v, override|
-        override.vm.network "private_network", :ip => "10.10.10.2#{i}", virtualbox__intnet: WARDROOM_NETWORK_NAME
-        v.memory = 4096
-        v.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
-      end
+      VagrantWardroom::Providers.configure(subconfig, ip: "10.10.10.2#{i}", memory: 4096)
     end
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:

Added a VagrantWardroom Ruby library that contains optimizations
for different Vagrant providers, and a common interface to
reconfiguring IPs and guest memory.

VirtualBox will imitate as the KVM hypervisor, enabling the use
of KVM paravirtualised drivers, and VTX is fully enabled which
should increase performance ~20%. Linked clones is also now
enabled so guest startup time is minimised.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

With thanks to @omahn for sharing some of these settings with me.

**Which issue(s) this PR fixes**:
N/A

**Applies to Kubernetes versions**:

N/A

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Optimized provider settings for Vagrant to improve performance.
```
