### PR TITLE
Add Makefile to build ansible-galaxy compatible tars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+.DEFAULT_GOAL:=help
+
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+all: ## Build Ansible Galaxy role archives
+	$(MAKE) galaxy-archive ROLE=common
+	$(MAKE) galaxy-archive ROLE=docker
+	$(MAKE) galaxy-archive ROLE=etcd
+	$(MAKE) galaxy-archive ROLE=kubernetes
+	$(MAKE) galaxy-archive ROLE=kubernetes-cni
+	$(MAKE) galaxy-archive ROLE=kubernetes-common
+	$(MAKE) galaxy-archive ROLE=kubernetes-master
+	$(MAKE) galaxy-archive ROLE=kubernetes-node
+	$(MAKE) galaxy-archive ROLE=kubernetes-user
+	$(MAKE) galaxy-archive ROLE=packer-cleanup
+	$(MAKE) galaxy-archive ROLE=providers
+	$(MAKE) galaxy-archive ROLE=test_loadbalancer
+
+build:
+	mkdir -p build
+
+galaxy-archive: build
+	cd ansible/roles/$(ROLE) && tar cfz ../../../build/wardroom-$(ROLE).tar.gz *
+
+clean: ## Delete build artifacts
+	-rm -rf build

--- a/ansible/roles/common/meta/main.yml
+++ b/ansible/roles/common/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/docker/meta/main.yml
+++ b/ansible/roles/docker/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/etcd/meta/main.yml
+++ b/ansible/roles/etcd/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/kubernetes-cni/meta/main.yml
+++ b/ansible/roles/kubernetes-cni/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/kubernetes-common/meta/main.yml
+++ b/ansible/roles/kubernetes-common/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/kubernetes-user/meta/main.yml
+++ b/ansible/roles/kubernetes-user/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/kubernetes/meta/main.yml
+++ b/ansible/roles/kubernetes/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/packer-cleanup/meta/main.yml
+++ b/ansible/roles/packer-cleanup/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/providers/meta/main.yml
+++ b/ansible/roles/providers/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---

--- a/ansible/roles/test_loadbalancer/meta/main.yml
+++ b/ansible/roles/test_loadbalancer/meta/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Wardroom Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If you update this file, please follow
+# https://suva.sh/posts/well-documented-makefiles
+
+---


### PR DESCRIPTION
Wanted to consume Wardroom as a third-party role, so this
creates tars for each role in the `build` directory.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close the issue(s) when PR gets merged)*
-->
N/A

**Applies to Kubernetes versions**:

- N/A

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Makefile allows you to run `make all` in order to produce ansible-galaxy compatible archives.
```
