### PR TITLE
Genericise OS support for Docker role

### DIFF
--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -3,3 +3,5 @@ docker_enable: True
 docker_debian_version: '5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release | lower }}'
 docker_redhat_version: '18.09.6-3*'
 docker_logging_max_size: 100m
+docker_channel: stable
+docker_distribution_release_version: "{{ ansible_distribution_major_version }}"

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 docker_enable: True
 docker_debian_version: '5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release | lower }}'
-docker_redhat_version: '18.09.5-3.el7'
+docker_redhat_version: '18.09.6-3*'
 docker_logging_max_size: 100m

--- a/ansible/roles/docker/meta/main.yml
+++ b/ansible/roles/docker/meta/main.yml
@@ -1,0 +1,3 @@
+---
+galaxy_info:
+  author: The Wardroom Authors

--- a/ansible/roles/docker/tasks/redhat.yml
+++ b/ansible/roles/docker/tasks/redhat.yml
@@ -1,9 +1,4 @@
 ---
-- name: add docker dependencies
-  yum:
-    name:
-      - device-mapper-persistent-data
-      - lvm2
 
 - name: add docker repo
   yum_repository:

--- a/ansible/roles/docker/tasks/redhat.yml
+++ b/ansible/roles/docker/tasks/redhat.yml
@@ -1,18 +1,24 @@
 ---
+- name: Set docker_os_distribution fact if RHEL family
+  set_fact: docker_os_distribution="centos"
+  when: ansible_distribution != "Fedora"
+
+- name: Set docker_os_distribution fact if Fedora
+  set_fact: docker_os_distribution="fedora"
+  when: ansible_distribution == "Fedora"
 
 - name: add docker repo
   yum_repository:
     name: docker
     description: Docker YUM repo
-    baseurl: https://download.docker.com/linux/centos/7/$basearch/stable/
-    gpgkey: https://download.docker.com/linux/centos/gpg
+    baseurl: "https://download.docker.com/linux/{{docker_os_distribution}}/{{docker_distribution_release_version}}/$basearch/{{docker_channel}}/"
+    gpgkey: "https://download.docker.com/linux/{{docker_os_distribution}}/gpg"
     gpgcheck: true
     state: present
 
 - name: install Docker binaries
-  yum:
-    name:
-    - docker-ce-{{docker_redhat_version}}
+  package:
+    name: "docker-ce-{{docker_redhat_version}}"
 
 - name: start docker service
   service:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:
* Makes the role a bit more generic in prep for CentOS/RHEL 8, and adds Fedora compatibility.
* Version of Docker for RedHat and friends bumped to 18.09.6-3 from 5-3.
* Makes the role exportable for use via Ansible Galaxy
* Removes old LVM DirectMapper support no longer used since CentOS 7.4

**Which issue(s) this PR fixes**:
<!--
  optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close the issue(s) when PR gets merged)*
-->
Fixes #

**Applies to Kubernetes versions**:

- `1.14`

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
