### PR TITLE
Export DEBIAN_FRONTEND=noninteractive env variable during python install

### DIFF
--- a/ansible/pre.yml
+++ b/ansible/pre.yml
@@ -4,7 +4,7 @@
   become: yes
   pre_tasks:
   - name: install python
-    raw: bash -c "if grep -qi debian /etc/os-release && [ ! -e /usr/bin/python ]; then apt -qqy update; apt install -qqy python python-pip; fi;"
+    raw: bash -c "export DEBIAN_FRONTEND=noninteractive; if grep -qi debian /etc/os-release && [ ! -e /usr/bin/python ]; then apt -qqy update; apt install -qqy python python-pip; fi;"
     register: output
     changed_when: output.stdout != ""
     retries: 3


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:
This PR sets the `DEBIAN_FRONTEND` environment variable to `noninteractive` when installing python on the base machine.

**Which issue(s) this PR fixes**:
<!--
  optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close the issue(s) when PR gets merged)*
-->
Fixes #192

