### PR TITLE
Update kubernetes-cni role to open BGP ports

### DIFF
--- a/ansible/roles/kubernetes-cni/tasks/calico.yml
+++ b/ansible/roles/kubernetes-cni/tasks/calico.yml
@@ -25,3 +25,14 @@
   retries: 10
   delay: 5
   when: kubernetes_cni_calico_install_calicoctl is defined and kubernetes_cni_calico_install_calicoctl|bool == True
+
+- name: open BGP ports
+  firewalld:
+    port: "{{ item }}"
+    permanent: yes
+    state: enabled
+    immediate: True
+  with_items:
+  - "179/tcp"
+  - "179/udp"
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'


### PR DESCRIPTION
Add task to kubernetes-cni role in the calico.yml task file to open BGP ports (179/tcp and 179/udp) using the firewalld module (only applies to CentOS/RHEL)

Signed-off-by: Scott Lowe <scott.lowe@scottlowe.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:
The default `firewalld` configuration on CentOS/RHEL systems blocks BGP (179/TCP and 179/UDP), which causes Calico not to function properly. This PR adds a section to the Calico playbook to open these ports.

**Which issue(s) this PR fixes**:
Fixes #201

**Applies to Kubernetes versions**:
This is not specific to any particular Kubernetes version. Although I have not verified this behavior with earlier versions of Kubernetes (it was tested with 1.14.x), there is no reason to believe that other versions are not affected. It is likely this change will need to be cherry-picked to other branches.

**Special notes for your reviewer**:
None

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
- Opens the necessary TCP and UDP ports for BGP (used by Calico) to function.
```
