### PR TITLE
Only apply the Canal RBAC when defined

### DIFF
--- a/ansible/roles/kubernetes-cni/tasks/canal.yml
+++ b/ansible/roles/kubernetes-cni/tasks/canal.yml
@@ -13,6 +13,7 @@
   delegate_to: "{{ groups['masters'][0] }}"
   retries: 10
   delay: 5
+  when: (item is defined) and (item != "") and (item is not none)
   with_items:
   - "{{ kubernetes_cni_canal_rbac_manifest_url }}"
   - /tmp/canal.yml


### PR DESCRIPTION
Newer versions of Canal do not include a separate RBAC manifest.
Therefore, only apply the manifest when it is defined.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>
