### PR TITLE
Only install the CNI components on masters

### DIFF
--- a/swizzle/install.yml
+++ b/swizzle/install.yml
@@ -63,7 +63,7 @@
 - import_playbook: add-nodes.yml
 
 - name: install CNI
-  hosts: all
+  hosts: masters
   become: yes
   roles:
     - kubernetes-cni


### PR DESCRIPTION
This moves the installation of CNI bits to the master nodes only.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close the issue(s) when PR gets merged)*
-->
Fixes #

**Applies to Kubernetes versions**:

- `1.`

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
