### PR TITLE
refactor to make use of new kubeadm capabilities

### DIFF
--- a/ansible/roles/kubernetes-common/defaults/main.yml
+++ b/ansible/roles/kubernetes-common/defaults/main.yml
@@ -8,16 +8,3 @@ kubernetes_common_primary_interface: eth0
 # kubelet_extra_args is a dict of arg:value (ie. 'node-ip: 1.1.1.1' for '--node-ip=1.1.1.1')
 kubernetes_common_kubelet_extra_args: {}
 kubernetes_common_kubelet_env_vars: {}
-kubernetes_common_kubelet_config: {}
-
-kubernetes_common_kubeadm_config:
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: ClusterConfiguration
-  kubernetesVersion: 1.15.3
-  controlPlaneEndpoint: "{{ kubernetes_common_api_fqdn }}"
-  apiServerExtraArgs:
-    "endpoint-reconciler-type": "lease"
-  apiServerCertSANs: "{{ kubernetes_common_api_ip | kube_lookup_hostname(kubernetes_common_api_fqdn, True) }}"
-  etcd:
-    external:
-      endpoints: "{{ etcd_client_endpoints }}"

--- a/ansible/roles/kubernetes-common/tasks/main.yml
+++ b/ansible/roles/kubernetes-common/tasks/main.yml
@@ -63,16 +63,5 @@
   - "10250-10255/tcp"
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
 
-- name: drop kubeadm template
-  template:
-    src: etc/kubernetes/kubeadm.conf
-    dest: /etc/kubernetes/kubeadm.conf
-
-- name: write kubelet configuration
-  template:
-    dest: /var/lib/kubelet/config.yaml
-    src: var/lib/kubelet/config.yaml
-  when: kubernetes_common_kubelet_config
-
 - name: flush handlers
   meta: flush_handlers

--- a/ansible/roles/kubernetes-common/templates/etc/kubernetes/kubeadm.conf
+++ b/ansible/roles/kubernetes-common/templates/etc/kubernetes/kubeadm.conf
@@ -1,2 +1,0 @@
----
-{{ kubernetes_common_kubeadm_config|to_nice_yaml(indent=2) }}

--- a/ansible/roles/kubernetes-common/templates/var/lib/kubelet/config.yaml
+++ b/ansible/roles/kubernetes-common/templates/var/lib/kubelet/config.yaml
@@ -1,2 +1,0 @@
----
-{{ kubernetes_common_kubelet_config|to_nice_yaml(indent=2) }}

--- a/ansible/roles/kubernetes-master/defaults/main.yml
+++ b/ansible/roles/kubernetes-master/defaults/main.yml
@@ -1,1 +1,21 @@
 ---
+kubernetes_common_kubeadm_config_clusterconfiguration:
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: ClusterConfiguration
+  kubernetesVersion: 1.15.3
+  controlPlaneEndpoint: "{{ kubernetes_common_api_fqdn }}"
+  apiServer:
+#    certSANs: "{{ kubernetes_common_api_ip | kube_lookup_hostname(kubernetes_common_api_fqdn, True) }}"  # Otherwise can't override with merge
+    extraArgs:
+      "endpoint-reconciler-type": "lease"
+  etcd:
+    external:
+      endpoints: "{{ etcd_client_endpoints }}"
+
+kubernetes_common_kubeadm_config_kubeletconfiguration:
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+
+kubernetes_common_kubeadm_config_initconfiguration:
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: InitConfiguration

--- a/ansible/roles/kubernetes-master/tasks/install.yml
+++ b/ansible/roles/kubernetes-master/tasks/install.yml
@@ -46,3 +46,16 @@
 - name: initialize secondary masters
   command: "/usr/bin/kubeadm init --config=/etc/kubernetes/kubeadm.conf --ignore-preflight-errors=all"
   when: kubeadm_apiserver_manifest.stat.exists == False and inventory_hostname != groups['primary_master']|first
+
+- name: Update kubelet config if already running
+  command: "kubeadm init phase kubelet-start --config /etc/kubernetes/kubeadm.conf"
+  when: kubeadm_apiserver_manifest.stat.exists == True
+
+- name: Update control plane manifests if already running
+  command: "kubeadm init phase control-plane all --config /etc/kubernetes/kubeadm.conf"
+  when: kubeadm_apiserver_manifest.stat.exists == True
+
+- name: Upload cluster configmaps
+  command: "kubeadm init phase upload-config all --config /etc/kubernetes/kubeadm.conf"
+  retries: 5
+  delay: 3

--- a/ansible/roles/kubernetes-master/tasks/main.yml
+++ b/ansible/roles/kubernetes-master/tasks/main.yml
@@ -6,6 +6,11 @@
       Please update your inventories
   when: kubernetes_master_kubeadm_config is defined
 
+- name: drop kubeadm template
+  template:
+    src: etc/kubernetes/kubeadm.conf
+    dest: /etc/kubernetes/kubeadm.conf
+
 - name: determine whether kubeadm needs to be run
   stat:
     path: /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/ansible/roles/kubernetes-master/tasks/upgrade.yml
+++ b/ansible/roles/kubernetes-master/tasks/upgrade.yml
@@ -1,5 +1,10 @@
 ---
-- name: add new control plane manifests
+- name: update kubelet config
+  command: "kubeadm init phase kubelet-start --config /etc/kubernetes/kubeadm.conf"
+  retries: 5
+  delay: 3
+
+- name: update new control plane manifests
   command: "kubeadm init phase control-plane all --config /etc/kubernetes/kubeadm.conf"
   retries: 5
   delay: 3
@@ -16,6 +21,11 @@
   delay: 1
   run_once: True
   delegate_to: "{{ groups['primary_master']|first }}"
+
+- name: upload cluster configmaps
+  command: "kubeadm init phase upload-config all --config /etc/kubernetes/kubeadm.conf"
+  retries: 5
+  delay: 3
 
 - name: add all of the kubernetes add-ons
   command: "kubeadm init phase addon all --config /etc/kubernetes/kubeadm.conf"

--- a/ansible/roles/kubernetes-master/templates/etc/kubernetes/kubeadm.conf
+++ b/ansible/roles/kubernetes-master/templates/etc/kubernetes/kubeadm.conf
@@ -1,0 +1,6 @@
+---
+{{ kubernetes_common_kubeadm_config_clusterconfiguration|to_nice_yaml(indent=2) }}
+---
+{{ kubernetes_common_kubeadm_config_kubeletconfiguration|to_nice_yaml(indent=2) }}
+---
+{{ kubernetes_common_kubeadm_config_initconfiguration|to_nice_yaml(indent=2) }}

--- a/ansible/roles/kubernetes-node/defaults/main.yml
+++ b/ansible/roles/kubernetes-node/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+kubernetes_common_kubeadm_config_initconfiguration:
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: InitConfiguration
+
+kubernetes_common_kubeadm_config_joinconfiguration:
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: JoinConfiguration
+  discovery:
+    bootstrapToken:
+      token: "{{ hostvars[groups['primary_master'][0]]['generated_token']['stdout'] }}"
+      apiServerEndpoint: "{{ kubernetes_common_api_fqdn }}:6443"
+      unsafeSkipCAVerification: true
+  nodeRegistration:
+    kubeletExtraArgs:
+      feature-gates: TTLAfterFinished=true

--- a/ansible/roles/kubernetes-node/tasks/main.yml
+++ b/ansible/roles/kubernetes-node/tasks/main.yml
@@ -1,13 +1,15 @@
 ---
-- name: check whether we have joined this node
-  shell: "/usr/bin/docker ps | /bin/grep kube-proxy"
-  register: kube_proxy_running
-  ignore_errors: True
+#- name: check whether we have joined this node
+#  shell: "/usr/bin/docker ps | /bin/grep kube-proxy"
+#  register: kube_proxy_running
+#  ignore_errors: True
 
+- name: update kubeadm template
+  template:
+    src: etc/kubernetes/kubeadm.conf
+    dest: /etc/kubernetes/kubeadm.conf
+
+# Note - always run this, updates kubeadm and kubelet config with any changes
+# Note - would be nice to only do if kubeadm template has changed, but it always changes as it contains join token
 - name: join nodes to masters by fqdn
-  command: "/usr/bin/kubeadm join {{ kubernetes_common_api_fqdn }}:6443 --token='{{ hostvars[groups['primary_master'][0]]['generated_token']['stdout'] }}' --discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=all"
-  when: kube_proxy_running is failed and ((kubernetes_common_api_fqdn is defined) and (kubernetes_common_api_fqdn != None) and (kubernetes_common_api_fqdn|trim != ''))
-
-- name: join nodes to masters by ip
-  command: "/usr/bin/kubeadm join {{ kubernetes_common_api_ip }}:6443 --token='{{ hostvars[groups['primary_master'][0]]['generated_token']['stdout'] }}' --discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=all"
-  when: kube_proxy_running is failed and ((kubernetes_common_api_fqdn is not defined) or (kubernetes_common_api_fqdn == None) or (kubernetes_common_api_fqdn|trim == ''))
+  command: "/usr/bin/kubeadm join phase kubelet-start --config /etc/kubernetes/kubeadm.conf"

--- a/ansible/roles/kubernetes-node/templates/etc/kubernetes/kubeadm.conf
+++ b/ansible/roles/kubernetes-node/templates/etc/kubernetes/kubeadm.conf
@@ -1,0 +1,4 @@
+---
+{{ kubernetes_common_kubeadm_config_initconfiguration|to_nice_yaml(indent=2) }}
+---
+{{ kubernetes_common_kubeadm_config_joinconfiguration|to_nice_yaml(indent=2) }}

--- a/swizzle/upgrade.yml
+++ b/swizzle/upgrade.yml
@@ -14,6 +14,16 @@
   - role: kubernetes-master
   tags: ['upgrade-control-plane']
 
+- name: create a kubeadm token
+  hosts: primary_master
+  become: yes
+  tasks:
+  - name: generate a kubeadm token
+    command: "/usr/bin/kubeadm token create --config /etc/kubernetes/kubeadm.conf --kubeconfig /etc/kubernetes/admin.conf"
+    register: generated_token
+    run_once: True
+    delegate_to: "{{ groups['primary_master']|first }}"
+
 - name: update the workers
   hosts: nodes
   become: yes


### PR DESCRIPTION
This change moves the kubeadm configurations to the respective node
types. This facilitates the ability to use kubeadm for kubelet
configuration. Similarly we now make use of the kubeadm ConfigMap via
kubeadm.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines
2. If the PR is unfinished, mark it as [WIP]
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close the issue(s) when PR gets merged)*
-->
Fixes #

**Applies to Kubernetes versions**:

- `1.`

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
